### PR TITLE
Bittrex: Add 0.001 BTC fee to withdrawals

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -24,6 +24,7 @@ post_url 2024-01-04-raccoin-0-2 %}).
 * Show new wallets expanded by default
 * Made the merging of consecutive trades optional
 * Added BTC price history (EUR) for 2024 (by Òscar Casajuana)
+* Bittrex CSV: Add 0.001 fee to BTC withdrawals (as with BCH)
 * macOS: Added universal binary support
 * macOS: Fixed app icon
 * Updated dependencies (Slint 1.13)

--- a/src/bittrex.rs
+++ b/src/bittrex.rs
@@ -106,9 +106,10 @@ impl From<BittrexTransaction> for Transaction {
             tx.tx_hash = Some(item.tx_id);
         }
 
-        // For BCH withdrawals from Bittrex, it appears a 0.001 BCH fee was
-        // charged, but the CSV does unfortunately not report withdrawal fees.
-        if tx.operation.is_send() && blockchain == "BCH" {
+        // For BTC and BCH withdrawals from Bittrex, it appears a 0.001 BTC/BCH
+        // fee was charged, but the CSV does unfortunately not report withdrawal
+        // fees.
+        if tx.operation.is_send() && (blockchain == "BTC" || blockchain == "BCH") {
             tx.fee = Some(Amount::new(Decimal::new(1, 3), blockchain.clone()));
         }
 


### PR DESCRIPTION
Unfortunately Bittrex withdrawal fees are not visible in the CSV export, but judging by my withdrawals it has been charging a 0.001 BTC fee, just like for BCH.