### PR TITLE
Fixed filtering on multiple conditions for transfers

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -20,6 +20,7 @@ post_url 2024-01-04-raccoin-0-2 %}).
 * Added support for per-wallet cost basis tracking ([#29](https://github.com/bjorn/raccoin/issues/29))
 * Fixed handling of currencies that contain numbers ([#17](https://github.com/bjorn/raccoin/issues/17))
 * Fixed handling of leap years in holding period calculation ([#32](https://github.com/bjorn/raccoin/issues/32))
+* Fixed filtering on multiple conditions for transfers ([#54](https://github.com/bjorn/raccoin/pull/54))
 * Adjust to bitcoin.de CSV format changes ([#31](https://github.com/bjorn/raccoin/issues/31))
 * Show new wallets expanded by default
 * Made the merging of consecutive trades optional

--- a/src/main.rs
+++ b/src/main.rs
@@ -1315,14 +1315,12 @@ fn ui_set_transactions(app: &App) {
     let mut ui_transactions = Vec::new();
 
     for transaction in transactions {
-        let filters_match = |transaction: &Transaction| {
-            filters.iter().all(|filter| filter.matches(transaction))
+        let matching_tx = transaction.matching_tx.map(|index| &transactions[index]);
+        let filter_matches = |filter: &TransactionFilter| {
+            filter.matches(transaction) || matching_tx.is_some_and(|tx| filter.matches(tx))
         };
 
-        if !filters_match(transaction) &&
-            (!transaction.operation.is_send() ||
-             !transaction.matching_tx.map(|index| filters_match(&transactions[index])).unwrap_or(false))
-        {
+        if !(filters.iter().all(filter_matches)) {
             continue;
         }
 


### PR DESCRIPTION
For transfers, the filtering required both the Send and the Receive transaction to match all active filters. Now all active filters need to match either the Send or the Receive transaction.