### PR TITLE
Support Trezor CSV files using ',' as delimiter

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -25,7 +25,8 @@ post_url 2024-01-04-raccoin-0-2 %}).
 * Handle airdrops as zero cost basis transactions ([#53](https://github.com/bjorn/raccoin/pull/53))
 * Adjust to bitcoin.de CSV format changes ([#31](https://github.com/bjorn/raccoin/issues/31))
 * Added support for new Bitstamp CSV format and detect SGB and FLR airdrops ([#51](https://github.com/bjorn/raccoin/pull/51))
-* Added support for more Poloniex CSV formats
+* Added support for more Poloniex CSV formats ([#57](https://github.com/bjorn/raccoin/pull/57))
+* Support Trezor CSV files using ',' as delimiter ([#56](https://github.com/bjorn/raccoin/pull/56))
 * Show new wallets expanded by default
 * Made the merging of consecutive trades optional
 * Added BTC price history (EUR) for 2024 (by Òscar Casajuana)

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,25 +115,27 @@ impl TransactionsSourceType {
                 return false;
             }
 
-            source_type.delimiter().is_some_and(|delimiter| {
+            source_type.delimiters().iter().any(|&delimiter| {
                 csv_file_has_headers(path, delimiter, source_type.skip_lines(), source_type.headers()).is_ok_and(|x| x)
             })
         })
     }
 
-    fn delimiter(&self) -> Option<u8> {
+    fn delimiters(&self) -> &'static [u8] {
         match self {
             TransactionsSourceType::BitcoinAddresses |
             TransactionsSourceType::BitcoinXpubs |
             TransactionsSourceType::EthereumAddress |
             TransactionsSourceType::StellarAccount |
             TransactionsSourceType::TrezorJson |
-            TransactionsSourceType::Json => None,
+            TransactionsSourceType::Json => &[],
 
-            TransactionsSourceType::BitcoinDeCsv |
-            TransactionsSourceType::TrezorCsv => Some(b';'),
+            TransactionsSourceType::BitcoinDeCsv => &[b';'],
 
-            _ => Some(b','),
+            // TrezorCsv used to use ';' but now uses ',', so we check both
+            TransactionsSourceType::TrezorCsv => &[b',', b';'],
+
+            _ => &[b','],
         }
     }
 


### PR DESCRIPTION
Previously Trezor Suite would export using `;` as delimiter, but when I export from current Trezor Suite I get files using `,`.