### PR TITLE
Make sure we remember whether a wallet is expanded

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -28,6 +28,7 @@ post_url 2024-01-04-raccoin-0-2 %}).
 * Added support for more Poloniex CSV formats ([#57](https://github.com/bjorn/raccoin/pull/57))
 * Support Trezor CSV files using ',' as delimiter ([#56](https://github.com/bjorn/raccoin/pull/56))
 * Show new wallets expanded by default
+* Fixed issue where wallets collapsed when making changes ([#62](https://github.com/bjorn/raccoin/issues/62))
 * Made the merging of consecutive trades optional
 * Added BTC price history (EUR) for 2024 (by Òscar Casajuana)
 * Bittrex CSV: Add 0.001 fee to BTC withdrawals (as with BCH)

--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -52,6 +52,8 @@ export global Facade {
 
     // params: (wallet_index, enabled)
     callback set-wallet-enabled(int, bool);
+    callback set-wallet-expanded(int, bool);
+
     // params: (wallet_index, source_index, enabled)
     callback set-source-enabled(int, int, bool);
 

--- a/raccoin_ui/ui/wallets.slint
+++ b/raccoin_ui/ui/wallets.slint
@@ -119,6 +119,7 @@ export component Wallets inherits ScrollView {
                     pointer-event(event) => {
                         if (event.kind == PointerEventKind.down) {
                             is-expanded = !is-expanded;
+                            Facade.set-wallet-expanded(wallet_index, is-expanded);
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1928,6 +1928,17 @@ async fn main() -> Result<()> {
         }
     });
 
+    facade.on_set_wallet_expanded({
+        let app = app.clone();
+
+        move |index, expanded| {
+            let mut app = app.borrow_mut();
+            if let Some(wallet) = app.portfolio.wallets.get_mut(index as usize) {
+                wallet.expanded = expanded;
+            }
+        }
+    });
+
     facade.on_set_source_enabled({
         let app = app.clone();
 


### PR DESCRIPTION
Otherwise it collapses when we refresh the model (for example, after toggling whether a wallet or one of its sources is enabled).

Closes #62