### PR TITLE
Fixed transaction filter and ignoring for NFTs

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -33,6 +33,7 @@ post_url 2024-01-04-raccoin-0-2 %}).
 * Support Trezor CSV files using ',' as delimiter ([#56](https://github.com/bjorn/raccoin/pull/56))
 * Show new wallets expanded by default
 * Fixed issue where wallets collapsed when making changes ([#62](https://github.com/bjorn/raccoin/issues/62))
+* Fixed "Ignore currency" and transaction filtering for NFTs
 * Made the merging of consecutive trades optional
 * Added BTC price history (EUR) for 2024 (by Òscar Casajuana)
 * Bittrex CSV: Add 0.001 fee to BTC withdrawals (as with BCH)


### PR DESCRIPTION
We need to compare the filter with the effective currency. For NFTs this currently means allocating temporary strings, but that shouldn't be too bad.

Also use binary search when checking ignored currencies, since the list of ignored currencies is sorted.