### PR TITLE
Fixed the fee_is_attached_when_transaction_id_matches test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: sudo apt update && sudo apt install libfontconfig-dev
     - run: cargo build --verbose --release
+    - run: cargo test --release
     - run: cargo install cargo-packager --locked
     - run: cargo packager --release
     - uses: actions/upload-artifact@v4

--- a/src/wave_space.rs
+++ b/src/wave_space.rs
@@ -287,7 +287,6 @@ mod tests {
     #[test]
     fn fee_is_attached_when_transaction_id_matches() {
         let csv = concat!(
-            "Type Category,Executes At,Transaction ID,Transaction Type,From Currency,From Amount,To Currency,To Amount,Memo\n",
             "FEE,2025-12-20 11:03:25,TX-ID,APPLICATION_FEE,BTC,0.00000586,BTC,0,fee memo\n",
             "TRANSACTION,2025-12-20 11:03:27,TX-ID,CARD_AUTHORIZATION,BTC,0.00058554,EUR,43.85,\n",
         );


### PR DESCRIPTION
Needed to be adjusted to last minute change that introduced the `parse_csv_rows` helper function.

Also, run the tests in CI so we notice when they start failing.