### PR TITLE
Make transaction explorer links explicit and opt-in

### DIFF
--- a/raccoin_ui/ui/common.slint
+++ b/raccoin_ui/ui/common.slint
@@ -40,13 +40,15 @@ export component SmallButton inherits Rectangle {
     in property text <=> i-text.text;
     in property tooltip <=> i-tooltip.text;
     in property tooltip-font-family <=> i-tooltip.font-family;
+    in property <bool> enabled: true;
     out property <bool> has-hover: i-touch.has-hover;
 
     callback clicked;
 
     border-radius: self.height / 4;
-    background: i-touch.has-hover ? #5e5e5e : #2e2e2e;
-    border-color: i-touch.has-hover ? #6e6e6e : #3e3e3e;
+    opacity: root.enabled ? 1.0 : 0.45;
+    background: root.enabled && i-touch.has-hover ? #5e5e5e : #2e2e2e;
+    border-color: root.enabled && i-touch.has-hover ? #6e6e6e : #3e3e3e;
     border-width: 1px;
     preferred-width: i-text.preferred-width + 5px;
     min-width: self.height;
@@ -56,8 +58,12 @@ export component SmallButton inherits Rectangle {
         vertical-alignment: center;
     }
     i-touch := TouchArea {
-        clicked => { root.clicked() }
-        mouse-cursor: pointer;
+        clicked => {
+            if (root.enabled) {
+                root.clicked()
+            }
+        }
+        mouse-cursor: root.enabled ? pointer : default;
     }
 
     Rectangle {

--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -32,6 +32,8 @@ export global Facade {
 
     in-out property <bool> updating-price-history: false;
     in-out property <float> updating-price-history-progress: 0.0;
+    in-out property <bool> open-transaction-links: false;
+    in-out property <string> transaction-url-template: "";
 
     // ACTIONS
 
@@ -54,8 +56,11 @@ export global Facade {
 
     callback ignore-currency(string);
 
-    // params: (blockchain, tx_hash)
-    callback open-transaction(string, string);
+    callback set-open-transaction-links(bool);
+    callback set-transaction-url-template(string);
+
+    // params: (url)
+    callback open-url(string);
 
     // params: (wallet_index, enabled)
     callback set-wallet-enabled(int, bool);

--- a/raccoin_ui/ui/structs.slint
+++ b/raccoin_ui/ui/structs.slint
@@ -57,6 +57,7 @@ export struct UiTransaction {
     description: string,
     tx_hash: string,
     blockchain: string,
+    block_explorer_url: string,
 }
 
 export struct UiCurrencySummary {

--- a/raccoin_ui/ui/transactions.slint
+++ b/raccoin_ui/ui/transactions.slint
@@ -1,4 +1,4 @@
-import { Button, ListView, HorizontalBox, LineEdit } from "std-widgets.slint";
+import { Button, CheckBox, ListView, HorizontalBox, LineEdit } from "std-widgets.slint";
 import {
     Cell,
     CurrencyIcon,
@@ -158,11 +158,14 @@ component TransactionDisplay inherits Rectangle {
 
             tx-btn := SmallButton {
                 visible: tx.tx-hash != "";
+                enabled: Facade.open-transaction-links && tx.block-explorer-url != "";
                 text: "#";
-                tooltip: tx.tx-hash;
+                tooltip: tx.block-explorer-url == "" ? tx.tx-hash :
+                    Facade.open-transaction-links ? tx.block-explorer-url :
+                    "Transaction links disabled: " + tx.block-explorer-url;
                 tooltip-font-family: "DejaVu Sans Mono";
 
-                clicked => { Facade.open-transaction(tx.blockchain, tx.tx-hash) }
+                clicked => { Facade.open-url(tx.block-explorer-url) }
             }
 
             desc-btn := SmallButton {
@@ -207,6 +210,16 @@ export component Transactions inherits VerticalLayout {
             edited => {
                 Facade.set-text-filter(self.text);
             }
+        }
+        CheckBox {
+            text: "Open transaction links";
+            checked <=> Facade.open-transaction-links;
+            toggled => { Facade.set-open-transaction-links(self.checked); }
+        }
+        LineEdit {
+            placeholder-text: "Explorer URL template";
+            text <=> Facade.transaction-url-template;
+            edited => { Facade.set-transaction-url-template(self.text); }
         }
         Button {
             icon: @image-url("icons/alert-triangle.svg");

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,10 @@ struct AppState {
     portfolio_file: Option<PathBuf>,
     last_source_directory: Option<PathBuf>,
     last_export_directory: Option<PathBuf>,
+    #[serde(default)]
+    open_transaction_links: bool,
+    #[serde(default)]
+    transaction_url_template: String,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -1308,30 +1312,97 @@ fn initialize_ui(app: &mut App) -> Result<AppWindow, slint::PlatformError> {
     facade.set_reports(app.ui_reports.clone().into());
     facade.set_portfolio(UiPortfolio::default());
     facade.set_notifications(ModelRc::new(VecModel::<UiNotification>::default()));
+    facade.set_open_transaction_links(app.state.open_transaction_links);
+    facade.set_transaction_url_template(app.state.transaction_url_template.clone().into());
 
-    facade.on_open_transaction(move |blockchain, tx_hash| {
-        let _ = match blockchain.as_str() {
-            "BCH" => open::that(format!("https://blockchair.com/bitcoin-cash/transaction/{}", tx_hash)),
-            "BTC" | "" => open::that(format!("https://blockchair.com/bitcoin/transaction/{}", tx_hash)),
-            // or "https://btc.com/tx/{}"
-            // or "https://live.blockcypher.com/btc/tx/{}"
-            "DASH" => open::that(format!("https://live.blockcypher.com/dash/tx/{}", tx_hash)),
-            "ETH" => open::that(format!("https://etherscan.io/tx/{}", tx_hash)),
-            "LTC" => open::that(format!("https://blockchair.com/litecoin/transaction/{}", tx_hash)),
-            "PPC" => open::that(format!("https://explorer.peercoin.net/tx/{}", tx_hash)),
-            "RDD" => open::that(format!("https://rddblockexplorer.com/tx/{}", tx_hash)),
-            "XLM" => open::that(format!("https://stellar.expert/explorer/public/tx/{}", tx_hash)),
-            "XMR" => open::that(format!("https://blockchair.com/monero/transaction/{}", tx_hash)),
-            "XRP" => open::that(format!("https://xrpscan.com/tx/{}", tx_hash)),
-            "ZEC" => open::that(format!("https://blockchair.com/zcash/transaction/{}", tx_hash)),
-            _ => {
-                println!("No explorer URL defined for blockchain: {}", blockchain);
-                Ok(())
-            }
-        };
+    facade.on_open_url(move |url| {
+        let _ = open::that(url.as_str());
     });
 
     Ok(ui)
+}
+
+fn default_transaction_url_template(blockchain: &str) -> Option<&'static str> {
+    match blockchain {
+        "BCH" => Some("https://blockchair.com/bitcoin-cash/transaction/{tx_hash}"),
+        "BTC" | "" => Some("https://blockchair.com/bitcoin/transaction/{tx_hash}"),
+        "DASH" => Some("https://live.blockcypher.com/dash/tx/{tx_hash}"),
+        "ETH" => Some("https://etherscan.io/tx/{tx_hash}"),
+        "LTC" => Some("https://blockchair.com/litecoin/transaction/{tx_hash}"),
+        "PPC" => Some("https://explorer.peercoin.net/tx/{tx_hash}"),
+        "RDD" => Some("https://rddblockexplorer.com/tx/{tx_hash}"),
+        "XLM" => Some("https://stellar.expert/explorer/public/tx/{tx_hash}"),
+        "XMR" => Some("https://blockchair.com/monero/transaction/{tx_hash}"),
+        "XRP" => Some("https://xrpscan.com/tx/{tx_hash}"),
+        "ZEC" => Some("https://blockchair.com/zcash/transaction/{tx_hash}"),
+        _ => None,
+    }
+}
+
+fn expand_transaction_url_template(template: &str, blockchain: &str, tx_hash: &str) -> String {
+    let normalized_blockchain = if blockchain.is_empty() { "BTC" } else { blockchain };
+    let expanded = template
+        .replace("{blockchain}", normalized_blockchain)
+        .replace("{tx_hash}", tx_hash)
+        .replace("{hash}", tx_hash);
+
+    if expanded == template {
+        format!("{template}{tx_hash}")
+    } else {
+        expanded
+    }
+}
+
+fn transaction_url(blockchain: &str, tx_hash: &str, custom_template: &str) -> Option<String> {
+    if tx_hash.is_empty() {
+        return None;
+    }
+
+    let template = if custom_template.trim().is_empty() {
+        default_transaction_url_template(blockchain)?
+    } else {
+        custom_template.trim()
+    };
+
+    Some(expand_transaction_url_template(template, blockchain, tx_hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_url_uses_default_template() {
+        assert_eq!(
+            transaction_url("BTC", "abc123", "").as_deref(),
+            Some("https://blockchair.com/bitcoin/transaction/abc123"),
+        );
+    }
+
+    #[test]
+    fn transaction_url_replaces_custom_template_placeholders() {
+        assert_eq!(
+            transaction_url("BTC", "abc123", "http://127.0.0.1:3002/{blockchain}/tx/{tx_hash}").as_deref(),
+            Some("http://127.0.0.1:3002/BTC/tx/abc123"),
+        );
+    }
+
+    #[test]
+    fn transaction_url_appends_hash_to_custom_base_url() {
+        assert_eq!(
+            transaction_url("BTC", "abc123", "http://127.0.0.1:3002/tx/").as_deref(),
+            Some("http://127.0.0.1:3002/tx/abc123"),
+        );
+    }
+
+    #[test]
+    fn transaction_url_requires_known_chain_or_custom_template() {
+        assert!(transaction_url("DOGE", "abc123", "").is_none());
+        assert_eq!(
+            transaction_url("DOGE", "abc123", "http://127.0.0.1:3002/{hash}").as_deref(),
+            Some("http://127.0.0.1:3002/abc123"),
+        );
+    }
 }
 
 fn ui_set_wallets(app: &App) {
@@ -1514,6 +1585,13 @@ fn ui_set_transactions(app: &App) {
         }
 
         let timestamp = Local.from_utc_datetime(&transaction.timestamp).naive_local();
+        let block_explorer_url = tx_hash
+            .and_then(|hash| transaction_url(
+                blockchain.map(String::as_str).unwrap_or_default(),
+                hash,
+                &app.state.transaction_url_template,
+            ))
+            .unwrap_or_default();
 
         ui_transactions.push(UiTransaction {
             id: transaction.index as i32,
@@ -1533,6 +1611,7 @@ fn ui_set_transactions(app: &App) {
             description: description.unwrap_or_default().into(),
             tx_hash: tx_hash.map(|s| s.to_owned()).unwrap_or_default().into(),
             blockchain: blockchain.map(|s| s.to_owned()).unwrap_or_default().into(),
+            block_explorer_url: block_explorer_url.into(),
         });
     }
 
@@ -2215,6 +2294,37 @@ async fn main() -> Result<()> {
                     }
                 }
                 _ => {}
+            }
+        }
+    });
+
+    facade.on_set_open_transaction_links({
+        let app = app.clone();
+
+        move |enabled| {
+            let mut app = app.borrow_mut();
+            app.state.open_transaction_links = enabled;
+            if let Err(e) = app.save_state() {
+                println!("Error saving application state: {}", e);
+            }
+        }
+    });
+
+    facade.on_set_transaction_url_template({
+        let app = app.clone();
+
+        move |template| {
+            let mut app = app.borrow_mut();
+            let template = template.to_string();
+            if app.state.transaction_url_template == template {
+                return;
+            }
+
+            app.state.transaction_url_template = template;
+            ui_set_transactions(&app);
+
+            if let Err(e) = app.save_state() {
+                println!("Error saving application state: {}", e);
             }
         }
     });


### PR DESCRIPTION
## Summary
- show each transaction's resolved explorer URL in the UI before opening it
- make external transaction links a persisted opt-in setting
- add an optional explorer URL template override for local/trusted explorers
- route transaction buttons through a URL-only open callback

Refs #33.

## Testing
- `CARGO_HOME=/Users/jpappas/code/codex-3/raccoin-33/.cargo-home cargo test`

Payout address if awarded: BTC `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`. If a Lightning invoice is required for the 50,000 sat bounty, I can provide one before settlement.