### PR TITLE
Make holding period configurable per portfolio

### DIFF
--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -41,6 +41,7 @@ export global Facade {
 
     callback set-merge-consecutive-trades(bool);
     callback set-cost-basis-tracking(UiCostBasisTracking);
+    callback set-long-term-holding-period(string);
 
     callback add-wallet(string);
     callback remove-wallet(int);

--- a/raccoin_ui/ui/portfolio.slint
+++ b/raccoin_ui/ui/portfolio.slint
@@ -1,4 +1,4 @@
-import { GroupBox, VerticalBox, HorizontalBox, ListView, Button, CheckBox, Spinner } from "std-widgets.slint";
+import { GroupBox, VerticalBox, HorizontalBox, ListView, Button, CheckBox, LineEdit, Spinner } from "std-widgets.slint";
 import {
     Cell,
     CurrencyCell,
@@ -82,6 +82,23 @@ export component Portfolio inherits Rectangle {
                     checked: Facade.portfolio.merge-consecutive-trades;
                     toggled => {
                         Facade.set-merge-consecutive-trades(self.checked);
+                    }
+                }
+                HorizontalBox {
+                    padding: 0;
+                    Text {
+                        text: "Long-term holding period";
+                        vertical-alignment: center;
+                    }
+                    period-input := LineEdit {
+                        text: Facade.portfolio.long-term-holding-period;
+                        placeholder-text: "1 year";
+                        width: 100px;
+                        horizontal-stretch: 0;
+                    }
+                    Button {
+                        text: "Apply";
+                        clicked => { Facade.set-long-term-holding-period(period-input.text); }
                     }
                 }
 

--- a/raccoin_ui/ui/structs.slint
+++ b/raccoin_ui/ui/structs.slint
@@ -142,6 +142,7 @@ export struct UiPortfolio {
     holdings: [UiCurrencyHoldings],
     merge_consecutive_trades: bool,
     cost_basis_tracking: UiCostBasisTracking,
+    long_term_holding_period: string,
 }
 
 export enum UiNotificationType {

--- a/raccoin_ui/ui/test-data.slint
+++ b/raccoin_ui/ui/test-data.slint
@@ -182,6 +182,7 @@ export global TestData {
         }],
         merge_consecutive_trades: false,
         cost_basis_tracking: UiCostBasisTracking.per-wallet,
+        long_term_holding_period: "1 year",
     };
 
     out property <[UiBalanceForWallet]> balances-for-wallet : [{

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -1,16 +1,62 @@
-use std::{collections::{VecDeque, HashMap}, path::Path};
+use std::{collections::{VecDeque, HashMap}, fmt, path::Path, str::FromStr};
 
 use anyhow::Result;
 use chrono::{NaiveDateTime, TimeZone, Local, Duration, Months};
 use rust_decimal::{Decimal, RoundingStrategy};
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[allow(dead_code)]
-pub enum HoldingPeriod {
+pub(crate) enum HoldingPeriod {
     Days(u32),
     Months(u32),
     Years(u32),
+}
+
+impl Default for HoldingPeriod {
+    fn default() -> Self {
+        Self::Years(1)
+    }
+}
+
+impl fmt::Display for HoldingPeriod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn write_unit(f: &mut fmt::Formatter<'_>, amount: u32, singular: &str, plural: &str) -> fmt::Result {
+            write!(f, "{} {}", amount, if amount == 1 { singular } else { plural })
+        }
+
+        match *self {
+            HoldingPeriod::Days(days) => write_unit(f, days, "day", "days"),
+            HoldingPeriod::Months(months) => write_unit(f, months, "month", "months"),
+            HoldingPeriod::Years(years) => write_unit(f, years, "year", "years"),
+        }
+    }
+}
+
+impl FromStr for HoldingPeriod {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim().to_ascii_lowercase().replace(' ', "");
+        let digit_count = value.chars().take_while(|c| c.is_ascii_digit()).count();
+        if digit_count == 0 {
+            return Err("expected a duration such as '1 year' or '183 days'".to_owned());
+        }
+
+        let amount: u32 = value[..digit_count]
+            .parse()
+            .map_err(|_| "duration amount is too large".to_owned())?;
+        if amount == 0 {
+            return Err("duration amount must be greater than zero".to_owned());
+        }
+
+        match &value[digit_count..] {
+            "" | "d" | "day" | "days" => Ok(Self::Days(amount)),
+            "m" | "month" | "months" => Ok(Self::Months(amount)),
+            "y" | "year" | "years" => Ok(Self::Years(amount)),
+            _ => Err("duration unit must be days, months, or years".to_owned()),
+        }
+    }
 }
 
 impl HoldingPeriod {
@@ -573,7 +619,11 @@ impl FIFO {
     }
 }
 
-pub(crate) fn save_gains_to_csv(gains: &Vec<CapitalGain>, output_path: &Path) -> Result<()> {
+pub(crate) fn save_gains_to_csv(
+    gains: &Vec<CapitalGain>,
+    output_path: &Path,
+    long_term_holding_period: HoldingPeriod,
+) -> Result<()> {
     let mut wtr = csv::Writer::from_path(output_path)?;
 
     #[derive(Serialize)]
@@ -605,7 +655,7 @@ pub(crate) fn save_gains_to_csv(gains: &Vec<CapitalGain>, output_path: &Path) ->
             cost: gain.cost.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero),
             proceeds: gain.proceeds.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero),
             gain_or_loss: (gain.proceeds - gain.cost).round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero),
-            long_term: gain.long_term(),
+            long_term: gain.is_held_for_at_least(long_term_holding_period),
         })?;
     }
 
@@ -658,6 +708,20 @@ mod tests {
         // 183 days from 2021-01-01 00:00:00 is 2021-07-03 00:00:00
         assert!(!gain("2021-01-01 00:00:00", "2021-07-02 23:59:59").is_held_for_at_least(HoldingPeriod::Days(183)));
         assert!(gain("2021-01-01 00:00:00", "2021-07-03 00:00:00").is_held_for_at_least(HoldingPeriod::Days(183)));
+    }
+
+    #[test]
+    fn parses_holding_period_settings() {
+        assert_eq!("183 days".parse::<HoldingPeriod>(), Ok(HoldingPeriod::Days(183)));
+        assert_eq!("12m".parse::<HoldingPeriod>(), Ok(HoldingPeriod::Months(12)));
+        assert_eq!("1 year".parse::<HoldingPeriod>(), Ok(HoldingPeriod::Years(1)));
+    }
+
+    #[test]
+    fn displays_holding_period_settings() {
+        assert_eq!(HoldingPeriod::Days(183).to_string(), "183 days");
+        assert_eq!(HoldingPeriod::Months(1).to_string(), "1 month");
+        assert_eq!(HoldingPeriod::Years(1).to_string(), "1 year");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use coinmarketcap::CmcInterval;
 use base::{cmc_id, Amount, Operation, Transaction};
 use chrono::{Datelike, Duration, Local, TimeZone, Utc};
 use directories::ProjectDirs;
-use fifo::{CapitalGain, CostBasisTracking, FIFO};
+use fifo::{CapitalGain, CostBasisTracking, HoldingPeriod, FIFO};
 use raccoin_ui::*;
 use price_history::{PriceHistory, PriceRequirements, split_ranges};
 use regex::{Regex, RegexBuilder};
@@ -226,6 +226,8 @@ struct Portfolio {
     merge_consecutive_trades: bool,
     #[serde(default)]
     cost_basis_tracking: CostBasisTracking,
+    #[serde(default)]
+    long_term_holding_period: HoldingPeriod,
 }
 
 #[derive(Default, Clone)]
@@ -444,7 +446,11 @@ impl App {
     fn refresh_transactions(&mut self) {
         self.transactions = load_transactions(&mut self.portfolio).unwrap_or_default();
         estimate_transaction_values(&mut self.transactions, &self.price_history);
-        self.reports = calculate_tax_reports(&mut self.transactions, self.portfolio.cost_basis_tracking);
+        self.reports = calculate_tax_reports(
+            &mut self.transactions,
+            self.portfolio.cost_basis_tracking,
+            self.portfolio.long_term_holding_period,
+        );
     }
 
     fn ui(&self) -> AppWindow {
@@ -596,7 +602,11 @@ pub(crate) fn export_all_to(app: &App, output_path: &Path) -> Result<()> {
         save_summary_to_csv(report, &path)?;
 
         let path = output_path.join(format!("{}_capital_gains_report.csv", year));
-        fifo::save_gains_to_csv(&report.gains, &path)?;
+        fifo::save_gains_to_csv(
+            &report.gains,
+            &path,
+            app.portfolio.long_term_holding_period,
+        )?;
     }
     Ok(())
 }
@@ -1117,7 +1127,11 @@ fn collect_price_requirements(transactions: &[Transaction]) -> PriceRequirements
     requirements
 }
 
-fn calculate_tax_reports(transactions: &mut Vec<Transaction>, tracking: CostBasisTracking) -> Vec<TaxReport> {
+fn calculate_tax_reports(
+    transactions: &mut Vec<Transaction>,
+    tracking: CostBasisTracking,
+    long_term_holding_period: HoldingPeriod,
+) -> Vec<TaxReport> {
     let mut currencies = Vec::<CurrencySummary>::new();
 
     fn summary_for<'a>(currencies: &'a mut Vec<CurrencySummary>, currency: &str) -> &'a mut CurrencySummary {
@@ -1172,22 +1186,23 @@ fn calculate_tax_reports(transactions: &mut Vec<Transaction>, tracking: CostBasi
 
         for gain in &gains {
             let gain_or_loss = gain.profit();
+            let is_long_term = gain.is_held_for_at_least(long_term_holding_period);
 
             if gain_or_loss.is_sign_positive() {
-                if gain.long_term() {
+                if is_long_term {
                     long_term_capital_gains += gain_or_loss;
                 } else {
                     short_term_capital_gains += gain_or_loss;
                 }
             } else {
-                if gain.long_term() {
+                if is_long_term {
                     long_term_capital_losses -= gain_or_loss;
                 } else {
                     short_term_capital_losses -= gain_or_loss;
                 }
             }
 
-            if !gain.long_term() {
+            if !is_long_term {
                 short_term_cost += gain.cost;
                 short_term_proceeds += gain.proceeds;
             }
@@ -1568,7 +1583,7 @@ fn ui_set_reports(app: &App) {
                 cost: rounded_to_cent(gain.cost).try_into().unwrap(),
                 proceeds: rounded_to_cent(gain.proceeds).try_into().unwrap(),
                 gain_or_loss: rounded_to_cent(gain.profit()).try_into().unwrap(),
-                long_term: gain.long_term(),
+                long_term: gain.is_held_for_at_least(app.portfolio.long_term_holding_period),
             }
         }).collect();
         let ui_gains = Rc::new(VecModel::from(ui_gains));
@@ -1662,6 +1677,7 @@ fn ui_set_portfolio(app: &App) {
                 CostBasisTracking::PerWallet => UiCostBasisTracking::PerWallet,
             },
             merge_consecutive_trades: app.portfolio.merge_consecutive_trades,
+            long_term_holding_period: app.portfolio.long_term_holding_period.to_string().into(),
         });
     }
 }
@@ -1829,6 +1845,28 @@ async fn main() -> Result<()> {
             app.refresh_transactions();
             app.refresh_ui();
             app.save_portfolio(None);
+        }
+    });
+    facade.on_set_long_term_holding_period({
+        let app = app.clone();
+        move |holding_period| {
+            let mut app = app.borrow_mut();
+            match holding_period.as_str().parse::<HoldingPeriod>() {
+                Ok(holding_period) => {
+                    if app.portfolio.long_term_holding_period == holding_period {
+                        return;
+                    }
+
+                    app.portfolio.long_term_holding_period = holding_period;
+                    app.refresh_transactions();
+                    app.refresh_ui();
+                    app.save_portfolio(None);
+                }
+                Err(e) => {
+                    println!("Invalid long-term holding period '{}': {}", holding_period, e);
+                    ui_set_portfolio(&app);
+                }
+            }
         }
     });
 
@@ -2125,7 +2163,11 @@ async fn main() -> Result<()> {
             match save_csv_file("Export Capital Gains (CSV)", &file_name) {
                 Some(path) => {
                     // todo: provide this feedback in the UI
-                    match fifo::save_gains_to_csv(&report.gains, &path) {
+                    match fifo::save_gains_to_csv(
+                        &report.gains,
+                        &path,
+                        app.portfolio.long_term_holding_period,
+                    ) {
                         Ok(_) => {
                             println!("Saved gains to {}", path.display());
                         }


### PR DESCRIPTION
## Summary
- add a per-portfolio long-term holding period setting, defaulting to `1 year`
- accept `days`, `months`, and `years` values such as `183 days`, `12 months`, or `1 year`
- use the configured period when bucketing tax report gains/losses, rendering capital gains, and exporting capital gains CSVs

Refs #32.

## Testing
- `CARGO_HOME=/Users/jpappas/code/codex-3/raccoin-32/.cargo-home cargo test`

Payout address if awarded: BTC `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`. If a Lightning invoice is required for the 50,000 sat bounty, I can provide one before settlement.