### PR TITLE
Add encrypted portfolio storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +51,18 @@ checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "cipher",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -50,11 +71,25 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.3.2",
+ "aes 0.6.0",
+ "cipher 0.2.5",
+ "ctr 0.6.0",
+ "ghash 0.3.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
 ]
 
@@ -64,7 +99,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
@@ -74,7 +109,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
@@ -279,6 +314,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -966,6 +1013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,7 +1497,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.8.0",
  "base64 0.13.1",
  "hkdf",
  "hmac 0.10.1",
@@ -1626,6 +1692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1672,7 +1739,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2701,7 +2777,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.4.5",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.2",
 ]
 
 [[package]]
@@ -3629,6 +3715,15 @@ name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "input"
@@ -4881,6 +4976,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5057,7 +5163,19 @@ checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -5328,9 +5446,11 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 name = "raccoin"
 version = "0.2.0"
 dependencies = [
+ "aes-gcm 0.10.3",
  "alloy-chains",
  "alloy-primitives",
  "anyhow",
+ "argon2",
  "bitcoin",
  "chrono",
  "chrono-tz",
@@ -5340,6 +5460,7 @@ dependencies = [
  "esplora-client",
  "foundry-block-explorers",
  "futures",
+ "getrandom 0.2.17",
  "linkme",
  "open",
  "pathdiff",
@@ -7650,6 +7771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ include = ["src/**/*", "LICENSE", "README.md", "build.rs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aes-gcm = "0.10"
 alloy-chains = "0.2"
 alloy-primitives = "1.5"
 anyhow = "1.0.75"
+argon2 = "0.5"
 ciborium = "0.2"
 bitcoin = "0.32"
 chrono = { version = "0.4.31", features = ["serde"] }
@@ -25,6 +27,7 @@ directories = "6.0"
 esplora-client = { version = "0.12", default-features = false, features = ["async", "tokio"] }
 foundry-block-explorers = "0.22"
 futures = "0.3.28"
+getrandom = "0.2"
 linkme = "0.3"
 open = "5.0.0"
 pathdiff = "0.2.1"

--- a/raccoin_ui/ui/appwindow.slint
+++ b/raccoin_ui/ui/appwindow.slint
@@ -336,6 +336,69 @@ component AddWalletSourceDialog inherits Rectangle {
     }
 }
 
+component PasswordDialog inherits Rectangle {
+    in property <bool> confirm-password;
+    in-out property <string> password: "";
+    in-out property <string> repeated-password: "";
+
+    callback close-requested();
+    callback submitted(string);
+
+    preferred-width: 360px;
+
+    VerticalBox {
+        Text {
+            text: confirm-password
+                ? "Choose a password for the encrypted portfolio."
+                : "Enter the portfolio password.";
+            color: #b0b0b0;
+            font-size: 12px;
+            horizontal-alignment: center;
+        }
+        password-input := LineEdit {
+            text <=> root.password;
+            input-type: InputType.password;
+            placeholder-text: "Password";
+            preferred-width: 320px;
+            accepted => {
+                if (root.password != "" && (!root.confirm-password || root.password == root.repeated-password)) {
+                    root.submitted(root.password);
+                }
+            }
+        }
+        if (confirm-password): repeat-input := LineEdit {
+            text <=> root.repeated-password;
+            input-type: InputType.password;
+            placeholder-text: "Repeat password";
+            preferred-width: 320px;
+            accepted => {
+                if (root.password != "" && root.password == root.repeated-password) {
+                    root.submitted(root.password);
+                }
+            }
+        }
+        if (confirm-password && repeated-password != "" && password != repeated-password): Text {
+            text: "Passwords do not match.";
+            color: red;
+            font-size: 12px;
+            horizontal-alignment: center;
+        }
+        HorizontalBox {
+            padding: 0;
+            Button {
+                text: "Cancel";
+                clicked => { root.close-requested(); }
+            }
+            Rectangle { horizontal-stretch: 1; }
+            Button {
+                text: "Continue";
+                enabled: root.password != "" && (!root.confirm-password || root.password == root.repeated-password);
+                clicked => { root.submitted(root.password); }
+            }
+        }
+    }
+}
+
 component MainContent inherits Rectangle {
     property <Page> active-page: Page.sources;
     property <int> add-source-wallet-index: -1;
@@ -344,6 +407,9 @@ component MainContent inherits Rectangle {
     property <string> add-source-kind-label: "";
     property <string> add-source-input: "";
     property <string> add-source-name: "";
+
+    callback load-encrypted-requested();
+    callback save-encrypted-requested();
 
     function page-index(page: Page) -> int {
         if (page == Page.portfolio) { 0 }
@@ -366,6 +432,12 @@ component MainContent inherits Rectangle {
                 opacity: active-page == Page.portfolio ? 1 : 0;
                 visible: self.opacity > 0;
                 x: page-offset(Page.portfolio);
+                load-encrypted-requested() => {
+                    root.load-encrypted-requested();
+                }
+                save-encrypted-requested() => {
+                    root.save-encrypted-requested();
+                }
                 currency-filter-clicked(currency) => {
                     Facade.set-currency-filter(currency);
                     root.active-page = Page.transactions;
@@ -441,6 +513,8 @@ component MainContent inherits Rectangle {
 }
 
 component WelcomePage inherits Rectangle {
+    callback load-encrypted-requested();
+
     VerticalBox {
         width: Math.min(self.preferred-width, root.width);
         height: Math.min(self.preferred-height, root.height);
@@ -467,6 +541,10 @@ component WelcomePage inherits Rectangle {
                 text: "Load Portfolio";
                 clicked => { Facade.load-portfolio(); }
             }
+            Button {
+                text: "Load Encrypted";
+                clicked => { root.load-encrypted-requested(); }
+            }
         }
     }
 }
@@ -480,10 +558,50 @@ export component AppWindow inherits Window {
     preferred-width: 1200px;
     preferred-height: 640px;
 
+    property <int> password-action: 0; // 1 = load encrypted, 2 = save encrypted
+    property <string> password-input: "";
+    property <string> password-repeat: "";
+
+    public function show-password-dialog(action: int) {
+        root.password-action = action;
+        root.password-input = "";
+        root.password-repeat = "";
+        password-modal.show();
+    }
+
     MainContent {
         visible: Facade.portfolio.file-name != "";
+        load-encrypted-requested() => { root.show-password-dialog(1); }
+        save-encrypted-requested() => { root.show-password-dialog(2); }
     }
-    if (Facade.portfolio.file-name == ""): WelcomePage {}
+    if (Facade.portfolio.file-name == ""): WelcomePage {
+        load-encrypted-requested() => { root.show-password-dialog(1); }
+    }
+
+    password-modal := ModalDialog {
+        width: root.width;
+        height: root.height;
+
+        title: root.password-action == 2 ? "Save Encrypted Portfolio" : "Load Encrypted Portfolio";
+
+        PasswordDialog {
+            confirm-password: root.password-action == 2;
+            password <=> root.password-input;
+            repeated-password <=> root.password-repeat;
+
+            close-requested() => { password-modal.close(); }
+            submitted(password) => {
+                if (root.password-action == 1) {
+                    Facade.load-encrypted-portfolio(password);
+                } else if (root.password-action == 2) {
+                    Facade.save-encrypted-portfolio(password);
+                } else if (root.password-action == 3) {
+                    Facade.load-pending-encrypted-portfolio(password);
+                }
+                password-modal.close();
+            }
+        }
+    }
 
     HorizontalBox {
         alignment: center;

--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -37,6 +37,9 @@ export global Facade {
 
     callback new-portfolio();
     callback load-portfolio();
+    callback load-encrypted-portfolio(string);
+    callback load-pending-encrypted-portfolio(string);
+    callback save-encrypted-portfolio(string);
     callback close-portfolio();
 
     callback set-merge-consecutive-trades(bool);

--- a/raccoin_ui/ui/portfolio.slint
+++ b/raccoin_ui/ui/portfolio.slint
@@ -16,6 +16,8 @@ import { Facade } from "global.slint";
 
 export component Portfolio inherits Rectangle {
     callback currency-filter-clicked(string);
+    callback load-encrypted-requested();
+    callback save-encrypted-requested();
 
     VerticalBox {
         padding: 0;
@@ -51,8 +53,16 @@ export component Portfolio inherits Rectangle {
                         clicked => { Facade.load-portfolio(); }
                     }
                     Button {
+                        text: "Load Encrypted";
+                        clicked => { root.load-encrypted-requested(); }
+                    }
+                    Button {
                         text: "Close";
                         clicked => { Facade.close-portfolio(); }
+                    }
+                    Button {
+                        text: Facade.portfolio.encrypted ? "Save Encrypted Copy" : "Encrypt Copy";
+                        clicked => { root.save-encrypted-requested(); }
                     }
                     Button {
                         text: Facade.updating-price-history ? "Updating..." : "Update Price History";
@@ -68,6 +78,11 @@ export component Portfolio inherits Rectangle {
                         progress: Facade.updating-price-history-progress;
                         visible: Facade.updating-price-history;
                     }
+                }
+                Text {
+                    text: Facade.portfolio.encrypted ? "Encrypted portfolio" : "Plain JSON portfolio";
+                    color: gray;
+                    font-size: 11px;
                 }
                 CheckBox {
                     text: "Per-wallet cost basis tracking";

--- a/raccoin_ui/ui/structs.slint
+++ b/raccoin_ui/ui/structs.slint
@@ -136,6 +136,7 @@ export enum UiCostBasisTracking {
 
 export struct UiPortfolio {
     file-name: string,
+    encrypted: bool,
     balance: float,
     cost_base: float,
     unrealized_gains: float,

--- a/raccoin_ui/ui/test-data.slint
+++ b/raccoin_ui/ui/test-data.slint
@@ -146,6 +146,7 @@ export global TestData {
 
     out property <UiPortfolio> portfolio : {
         file-name: "portfolio.json",
+        encrypted: false,
         balance: 1000.00,
         cost_base: 1500.00,
         unrealized_gains: -500.00,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,21 +31,26 @@ mod trezor;
 mod wallet_of_satoshi;
 mod wave_space;
 
-use anyhow::{anyhow, Context, Result};
-use coinmarketcap::CmcInterval;
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use argon2::Argon2;
 use base::{cmc_id, Amount, Operation, Transaction};
 use chrono::{Datelike, Duration, Local, TimeZone, Utc};
+use coinmarketcap::CmcInterval;
 use directories::ProjectDirs;
 use fifo::{CapitalGain, CostBasisTracking, FIFO};
+use linkme::distributed_slice;
+use price_history::{split_ranges, PriceHistory, PriceRequirements};
 use raccoin_ui::*;
-use price_history::{PriceHistory, PriceRequirements, split_ranges};
 use regex::{Regex, RegexBuilder};
 use rust_decimal::{Decimal, RoundingStrategy};
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use slice_group_by::GroupByMut;
 use slint::{Model, ModelRc, SharedString, StandardListViewItem, VecModel};
-use linkme::distributed_slice;
 use std::{
     cell::RefCell,
     cmp::{Eq, Ordering},
@@ -64,6 +69,28 @@ use std::{
 
 fn rounded_to_cent(amount: Decimal) -> Decimal {
     amount.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero)
+}
+
+const ENCRYPTED_PORTFOLIO_MAGIC: &[u8] = b"RACCOIN-ENCRYPTED-PORTFOLIO\0";
+const ENCRYPTED_PORTFOLIO_VERSION: u8 = 1;
+const PORTFOLIO_KEY_LEN: usize = 32;
+const PORTFOLIO_SALT_LEN: usize = 16;
+const PORTFOLIO_NONCE_LEN: usize = 12;
+
+#[derive(Clone)]
+struct PortfolioEncryption {
+    salt: Vec<u8>,
+    key: [u8; PORTFOLIO_KEY_LEN],
+}
+
+#[derive(Serialize, Deserialize)]
+struct EncryptedPortfolioEnvelope {
+    version: u8,
+    kdf: String,
+    cipher: String,
+    salt: Vec<u8>,
+    nonce: Vec<u8>,
+    ciphertext: Vec<u8>,
 }
 
 pub(crate) type LoadFuture = Pin<Box<dyn Future<Output = Result<Vec<Transaction>>> + Send>>;
@@ -332,6 +359,8 @@ struct App {
     project_dirs: Option<ProjectDirs>,
     state: AppState,
     portfolio: Portfolio,
+    portfolio_encryption: Option<PortfolioEncryption>,
+    pending_encrypted_portfolio_file: Option<PathBuf>,
     transactions: Vec<Transaction>,
     reports: Vec<TaxReport>,
     price_history: PriceHistory,
@@ -344,6 +373,169 @@ struct App {
     ui_transactions: Rc<VecModel<UiTransaction>>,
     ui_report_years: Rc<VecModel<StandardListViewItem>>,
     ui_reports: Rc<VecModel<UiTaxReport>>,
+}
+
+fn is_encrypted_portfolio(bytes: &[u8]) -> bool {
+    bytes.starts_with(ENCRYPTED_PORTFOLIO_MAGIC)
+}
+
+fn fill_random(bytes: &mut [u8]) -> Result<()> {
+    getrandom::getrandom(bytes).context("Failed to get secure random bytes")
+}
+
+fn derive_portfolio_key(password: &str, salt: &[u8]) -> Result<[u8; PORTFOLIO_KEY_LEN]> {
+    if password.is_empty() {
+        bail!("Password cannot be empty");
+    }
+
+    let mut key = [0; PORTFOLIO_KEY_LEN];
+    Argon2::default()
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .map_err(|e| anyhow!("Failed to derive portfolio encryption key: {}", e))?;
+    Ok(key)
+}
+
+fn new_portfolio_encryption(password: &str) -> Result<PortfolioEncryption> {
+    let mut salt = vec![0; PORTFOLIO_SALT_LEN];
+    fill_random(&mut salt)?;
+    let key = derive_portfolio_key(password, &salt)?;
+    Ok(PortfolioEncryption { salt, key })
+}
+
+fn encrypt_portfolio_json(json: &[u8], encryption: &PortfolioEncryption) -> Result<Vec<u8>> {
+    let mut nonce = vec![0; PORTFOLIO_NONCE_LEN];
+    fill_random(&mut nonce)?;
+
+    let cipher = Aes256Gcm::new_from_slice(&encryption.key)
+        .map_err(|_| anyhow!("Invalid portfolio encryption key length"))?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce), json)
+        .map_err(|_| anyhow!("Failed to encrypt portfolio"))?;
+
+    let envelope = EncryptedPortfolioEnvelope {
+        version: ENCRYPTED_PORTFOLIO_VERSION,
+        kdf: "argon2id-default".to_owned(),
+        cipher: "aes-256-gcm".to_owned(),
+        salt: encryption.salt.clone(),
+        nonce,
+        ciphertext,
+    };
+
+    let mut bytes = Vec::from(ENCRYPTED_PORTFOLIO_MAGIC);
+    ciborium::ser::into_writer(&envelope, &mut bytes)
+        .context("Failed to encode encrypted portfolio")?;
+    Ok(bytes)
+}
+
+fn decrypt_portfolio_json(bytes: &[u8], password: &str) -> Result<(Vec<u8>, PortfolioEncryption)> {
+    let envelope_bytes = bytes
+        .strip_prefix(ENCRYPTED_PORTFOLIO_MAGIC)
+        .context("Missing encrypted portfolio header")?;
+    let envelope: EncryptedPortfolioEnvelope = ciborium::de::from_reader(envelope_bytes)
+        .context("Failed to decode encrypted portfolio")?;
+
+    if envelope.version != ENCRYPTED_PORTFOLIO_VERSION {
+        bail!("Unsupported encrypted portfolio version {}", envelope.version);
+    }
+    if envelope.kdf != "argon2id-default" {
+        bail!("Unsupported portfolio key derivation {}", envelope.kdf);
+    }
+    if envelope.cipher != "aes-256-gcm" {
+        bail!("Unsupported portfolio cipher {}", envelope.cipher);
+    }
+    if envelope.salt.len() != PORTFOLIO_SALT_LEN {
+        bail!("Invalid encrypted portfolio salt length");
+    }
+    if envelope.nonce.len() != PORTFOLIO_NONCE_LEN {
+        bail!("Invalid encrypted portfolio nonce length");
+    }
+
+    let key = derive_portfolio_key(password, &envelope.salt)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|_| anyhow!("Invalid portfolio encryption key length"))?;
+    let json = cipher
+        .decrypt(Nonce::from_slice(&envelope.nonce), envelope.ciphertext.as_ref())
+        .map_err(|_| anyhow!("Failed to decrypt portfolio. Check the password and try again."))?;
+
+    Ok((json, PortfolioEncryption { salt: envelope.salt, key }))
+}
+
+fn decode_portfolio(
+    bytes: &[u8],
+    password: Option<&str>,
+) -> Result<(Portfolio, Option<PortfolioEncryption>)> {
+    let (json, encryption) = if is_encrypted_portfolio(bytes) {
+        let password = password.context("This portfolio is encrypted. Use Load Encrypted Portfolio.")?;
+        let (json, encryption) = decrypt_portfolio_json(bytes, password)?;
+        (json, Some(encryption))
+    } else {
+        (bytes.to_vec(), None)
+    };
+
+    let portfolio = serde_json::from_slice(&json).context("Failed to parse portfolio")?;
+    Ok((portfolio, encryption))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn portfolio_with_wallet(name: &str) -> Portfolio {
+        Portfolio {
+            wallets: vec![Wallet::new(name.to_owned())],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn encrypted_portfolio_round_trips() {
+        let portfolio = portfolio_with_wallet("Cold storage");
+        let json = serde_json::to_vec_pretty(&portfolio).unwrap();
+        let encryption = new_portfolio_encryption("correct horse battery staple").unwrap();
+
+        let encrypted = encrypt_portfolio_json(&json, &encryption).unwrap();
+        assert!(is_encrypted_portfolio(&encrypted));
+        assert!(!String::from_utf8_lossy(&encrypted).contains("Cold storage"));
+
+        let (decoded, decoded_encryption) =
+            decode_portfolio(&encrypted, Some("correct horse battery staple")).unwrap();
+        assert_eq!(decoded.wallets[0].name, "Cold storage");
+        assert!(decoded_encryption.is_some());
+    }
+
+    #[test]
+    fn encrypted_portfolio_rejects_wrong_password() {
+        let portfolio = portfolio_with_wallet("Savings");
+        let json = serde_json::to_vec_pretty(&portfolio).unwrap();
+        let encryption = new_portfolio_encryption("right-password").unwrap();
+        let encrypted = encrypt_portfolio_json(&json, &encryption).unwrap();
+
+        assert!(decode_portfolio(&encrypted, Some("wrong-password")).is_err());
+    }
+
+    #[test]
+    fn encrypted_portfolio_requires_password() {
+        let portfolio = portfolio_with_wallet("Savings");
+        let json = serde_json::to_vec_pretty(&portfolio).unwrap();
+        let encryption = new_portfolio_encryption("right-password").unwrap();
+        let encrypted = encrypt_portfolio_json(&json, &encryption).unwrap();
+
+        let error = match decode_portfolio(&encrypted, None) {
+            Ok(_) => panic!("encrypted portfolio loaded without password"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("encrypted"));
+    }
+
+    #[test]
+    fn plain_portfolio_decodes_without_password() {
+        let portfolio = portfolio_with_wallet("Plain wallet");
+        let json = serde_json::to_vec_pretty(&portfolio).unwrap();
+
+        let (decoded, encryption) = decode_portfolio(&json, None).unwrap();
+        assert_eq!(decoded.wallets[0].name, "Plain wallet");
+        assert!(encryption.is_none());
+    }
 }
 
 impl App {
@@ -368,6 +560,8 @@ impl App {
             project_dirs,
             state,
             portfolio: Portfolio::default(),
+            portfolio_encryption: None,
+            pending_encrypted_portfolio_file: None,
             transactions: Vec::new(),
             reports: Vec::new(),
             price_history,
@@ -384,8 +578,12 @@ impl App {
     }
 
     fn load_portfolio(&mut self, file_path: &Path) -> Result<()> {
-        // todo: report portfolio loading error in UI
-        let mut portfolio: Portfolio = serde_json::from_str(&std::fs::read_to_string(file_path)?)?;
+        self.load_portfolio_with_password(file_path, None)
+    }
+
+    fn load_portfolio_with_password(&mut self, file_path: &Path, password: Option<&str>) -> Result<()> {
+        let bytes = std::fs::read(file_path)?;
+        let (mut portfolio, encryption) = decode_portfolio(&bytes, password)?;
         let portfolio_path = file_path.parent().unwrap_or(Path::new(""));
         portfolio.wallets.iter_mut().for_each(|w| w.sources.iter_mut().for_each(|source| {
             let source_definition = transaction_source_by_id(&source.source_type);
@@ -397,46 +595,67 @@ impl App {
 
         self.state.portfolio_file = Some(file_path.into());
         self.portfolio = portfolio;
+        self.portfolio_encryption = encryption;
 
         self.refresh_transactions();
         Ok(())
     }
 
-    fn save_portfolio(&mut self, portfolio_file: Option<PathBuf>) {
-        fn internal_save(portfolio: &Portfolio, portfolio_file: &Path) -> Result<()> {
-            let json = serde_json::to_string_pretty(&portfolio)?;
-            std::fs::write(portfolio_file, json)?;
-            Ok(())
-        }
-
-        if let Some(path) = portfolio_file.as_ref().or(self.state.portfolio_file.as_ref()) {
-            let portfolio_path = path.parent().unwrap_or(Path::new(""));
-            self.portfolio.wallets.iter_mut().for_each(|w| w.sources.iter_mut().for_each(|source| {
-                let source_definition = transaction_source_by_id(&source.source_type);
-                let is_virtual = source_definition.map(|definition| definition.load_sync.is_none()).unwrap_or(false);
-                if !is_virtual {
-                    if let Some(relative_path) = pathdiff::diff_paths(&source.full_path, portfolio_path) {
-                        source.path = relative_path.to_str().unwrap_or_default().to_owned();
-                    }
+    fn save_portfolio_to_path(
+        &mut self,
+        path: &Path,
+        encryption: Option<&PortfolioEncryption>,
+    ) -> Result<()> {
+        let portfolio_path = path.parent().unwrap_or(Path::new(""));
+        self.portfolio.wallets.iter_mut().for_each(|w| w.sources.iter_mut().for_each(|source| {
+            let source_definition = transaction_source_by_id(&source.source_type);
+            let is_virtual = source_definition.map(|definition| definition.load_sync.is_none()).unwrap_or(false);
+            if !is_virtual {
+                if let Some(relative_path) = pathdiff::diff_paths(&source.full_path, portfolio_path) {
+                    source.path = relative_path.to_str().unwrap_or_default().to_owned();
                 }
-            }));
+            }
+        }));
 
-            match internal_save(&self.portfolio, path) {
+        let json = serde_json::to_vec_pretty(&self.portfolio)?;
+        let bytes = if let Some(encryption) = encryption {
+            encrypt_portfolio_json(&json, encryption)?
+        } else {
+            json
+        };
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    fn save_portfolio(&mut self, portfolio_file: Option<PathBuf>) {
+        let encryption = self.portfolio_encryption.clone();
+        let target_path = portfolio_file.clone().or_else(|| self.state.portfolio_file.clone());
+        if let Some(path) = target_path.as_ref() {
+            match self.save_portfolio_to_path(path, encryption.as_ref()) {
                 Ok(_) => {
                     println!("Saved portfolio to {}", path.display());
                     if portfolio_file.is_some() {
                         self.state.portfolio_file = portfolio_file;
                     }
                 }
-                Err(_) => {
-                    println!("Error saving portfolio to {}", path.display());
+                Err(e) => {
+                    println!("Error saving portfolio to {}: {}", path.display(), e);
                 }
             }
         }
     }
 
+    fn save_encrypted_portfolio(&mut self, path: PathBuf, password: &str) -> Result<()> {
+        let encryption = new_portfolio_encryption(password)?;
+        self.save_portfolio_to_path(&path, Some(&encryption))?;
+        self.portfolio_encryption = Some(encryption);
+        self.state.portfolio_file = Some(path);
+        Ok(())
+    }
+
     fn close_portfolio(&mut self) {
         self.portfolio = Portfolio::default();
+        self.portfolio_encryption = None;
         self.state.portfolio_file = None;
         self.refresh_transactions();
     }
@@ -1653,6 +1872,7 @@ fn ui_set_portfolio(app: &App) {
 
         facade.set_portfolio(UiPortfolio {
             file_name: app.state.portfolio_file.as_deref().map(Path::to_string_lossy).unwrap_or_default().to_string().into(),
+            encrypted: app.portfolio_encryption.is_some(),
             balance: rounded_to_cent(balance).try_into().unwrap(),
             cost_base: rounded_to_cent(cost_base).try_into().unwrap(),
             unrealized_gains: rounded_to_cent(balance - cost_base).try_into().unwrap(),
@@ -1672,11 +1892,21 @@ async fn main() -> Result<()> {
 
     // Load portfolio from command-line or from previous application state
     if let Some(portfolio_file) = env::args_os().nth(1).map(OsString::into).or_else(|| app.state.portfolio_file.to_owned()) {
-        if let Err(e) = app.load_portfolio(&portfolio_file) {
-            println!("Error loading portfolio from {}: {}", portfolio_file.display(), e);
-            return Ok(());
+        let encrypted = std::fs::read(&portfolio_file)
+            .map(|bytes| is_encrypted_portfolio(&bytes))
+            .unwrap_or(false);
+
+        if encrypted {
+            println!("Portfolio {} is encrypted; waiting for password", portfolio_file.display());
+            app.pending_encrypted_portfolio_file = Some(portfolio_file);
+            app.state.portfolio_file = None;
+        } else {
+            if let Err(e) = app.load_portfolio(&portfolio_file) {
+                println!("Error loading portfolio from {}: {}", portfolio_file.display(), e);
+                return Ok(());
+            }
+            println!("Restored portfolio {}", portfolio_file.display());
         }
-        println!("Restored portfolio {}", portfolio_file.display());
     }
 
     let ui = initialize_ui(&mut app)?;
@@ -1767,6 +1997,7 @@ async fn main() -> Result<()> {
                 Some(path) => {
                     let mut app = app.borrow_mut();
                     app.portfolio = Portfolio::default();
+                    app.portfolio_encryption = None;
                     app.save_portfolio(Some(path));
                     app.refresh_transactions();
                     app.refresh_ui();
@@ -1788,8 +2019,78 @@ async fn main() -> Result<()> {
                 Some(path) => {
                     let mut app = app.borrow_mut();
                     if let Err(e) = app.load_portfolio(&path) {
-                        println!("Error loading portfolio from {}: {}", path.display(), e);
+                        app.report_error(&format!("Error loading portfolio: {}", e));
                     } else {
+                        app.refresh_ui();
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    facade.on_load_encrypted_portfolio({
+        let app = app.clone();
+
+        move |password| {
+            let dialog = rfd::FileDialog::new()
+                .set_title("Load Encrypted Portfolio")
+                .add_filter("Encrypted Portfolio", &["raccoin"])
+                .add_filter("Portfolio (JSON)", &["json"]);
+
+            match dialog.pick_file() {
+                Some(path) => {
+                    let mut app = app.borrow_mut();
+                    if let Err(e) = app.load_portfolio_with_password(&path, Some(password.as_str())) {
+                        app.report_error(&format!("Error loading encrypted portfolio: {}", e));
+                    } else {
+                        app.pending_encrypted_portfolio_file = None;
+                        app.refresh_ui();
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    facade.on_load_pending_encrypted_portfolio({
+        let app = app.clone();
+
+        move |password| {
+            let path = app.borrow().pending_encrypted_portfolio_file.clone();
+            match path {
+                Some(path) => {
+                    let mut app = app.borrow_mut();
+                    if let Err(e) = app.load_portfolio_with_password(&path, Some(password.as_str())) {
+                        app.report_error(&format!("Error loading encrypted portfolio: {}", e));
+                    } else {
+                        app.pending_encrypted_portfolio_file = None;
+                        app.refresh_ui();
+                    }
+                }
+                None => {
+                    app.borrow().report_error("No encrypted portfolio is waiting to be loaded.");
+                }
+            }
+        }
+    });
+
+    facade.on_save_encrypted_portfolio({
+        let app = app.clone();
+
+        move |password| {
+            let dialog = rfd::FileDialog::new()
+                .set_title("Save Encrypted Portfolio")
+                .set_file_name("Portfolio.raccoin")
+                .add_filter("Encrypted Portfolio", &["raccoin"]);
+
+            match dialog.save_file() {
+                Some(path) => {
+                    let mut app = app.borrow_mut();
+                    if let Err(e) = app.save_encrypted_portfolio(path, password.as_str()) {
+                        app.report_error(&format!("Error saving encrypted portfolio: {}", e));
+                    } else {
+                        app.report_info("Encrypted portfolio saved.");
                         app.refresh_ui();
                     }
                 }
@@ -2260,6 +2561,10 @@ async fn main() -> Result<()> {
             ui_set_transactions(&app);
         }
     });
+
+    if app.borrow().pending_encrypted_portfolio_file.is_some() {
+        ui.invoke_show_password_dialog(3);
+    }
 
     ui.show()?;
 


### PR DESCRIPTION
Closes #47.

Summary:
- Add password-protected portfolio files using Argon2id key derivation and AES-256-GCM encryption.
- Keep plain JSON portfolios compatible while detecting encrypted files with a magic header.
- Add UI flows to save encrypted copies, load encrypted portfolios, and unlock encrypted startup restores.
- Auto-save encrypted portfolios with a session-held derived key after loading/saving encrypted files.
- Add tests for plain decoding, encrypted round-trip, missing password, and wrong password.

Tests:
- `env CARGO_HOME=/private/tmp/raccoin-78-cargo-home cargo test`
- `git diff --check`

Payout address: BTC `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`
