### PR TITLE
Add Bitcoin descriptor scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Raccoin can import CSV files exported from the following sources:
 
 Raccoin can also synchronize wallets from certain blockchains directly. Supported are:
 
-* [Bitcoin](https://bitcoin.org/) wallets (either plain addresses or x/y/zpub addresses)
+* [Bitcoin](https://bitcoin.org/) wallets (plain addresses, x/y/zpub addresses or output descriptors)
 * [Ethereum](https://ethereum.org/) wallets
 * [Stellar](https://stellar.org/) accounts
 

--- a/raccoin_ui/ui/appwindow.slint
+++ b/raccoin_ui/ui/appwindow.slint
@@ -238,25 +238,30 @@ component AddWalletSourceDialog inherits Rectangle {
             text: "Bitcoin HD Wallet(s)";
             clicked => { root.select-kind("BitcoinXpubs", "Bitcoin HD Wallet(s)"); }
         }
+        Button {
+            row: 3; col: 1; colspan: 2;
+            text: "Bitcoin Descriptor(s)";
+            clicked => { root.select-kind("BitcoinDescriptors", "Bitcoin Descriptor(s)"); }
+        }
 
         Text {
-            row: 3; col: 0;
+            row: 4; col: 0;
             text: "Ethereum";
             vertical-alignment: TextVerticalAlignment.center;
         }
         Button {
-            row: 3; col: 1; colspan: 2;
+            row: 4; col: 1; colspan: 2;
             text: "Ethereum Address";
             clicked => { root.select-kind("EthereumAddress", "Ethereum Address"); }
         }
 
         Text {
-            row: 4; col: 0;
+            row: 5; col: 0;
             text: "Stellar";
             vertical-alignment: TextVerticalAlignment.center;
         }
         Button {
-            row: 4; col: 1; colspan: 2;
+            row: 5; col: 1; colspan: 2;
             text: "Stellar Account";
             clicked => { root.select-kind("StellarAccount", "Stellar Address"); }
         }
@@ -277,6 +282,8 @@ component AddWalletSourceDialog inherits Rectangle {
                     "Address(es), separated by spaces";
                 } else if (kind-id == "BitcoinXpubs") {
                     "Extended Public Key(s), separated by spaces";
+                } else if (kind-id == "BitcoinDescriptors") {
+                    "Output Descriptor(s), separated by spaces";
                 } else if (kind-id == "StellarAccount") {
                     "Stellar Account ID";
                 } else if (kind-id == "EthereumAddress") {
@@ -297,7 +304,7 @@ component AddWalletSourceDialog inherits Rectangle {
             font-size: 12px;
             color: #666;
             text: {
-                if (kind-id == "BitcoinAddresses" || kind-id == "BitcoinXpubs") {
+                if (kind-id == "BitcoinAddresses" || kind-id == "BitcoinXpubs" || kind-id == "BitcoinDescriptors") {
                     "Synced using https://blockstream.info/";
                 } else if (kind-id == "StellarAccount") {
                     "Synced using https://horizon.stellar.org/";

--- a/src/esplora.rs
+++ b/src/esplora.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use std::{str::FromStr, collections::{HashMap, HashSet, hash_map::Entry}};
 use bitcoin::{Address, Network, bip32::{Xpub, DerivationPath, ChildNumber}, secp256k1::{Secp256k1, self}, base58, ScriptBuf};
 use chrono::DateTime;
@@ -123,11 +123,34 @@ async fn address_txs(
     Ok(txs)
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AddressType {
     P2PKH,          // Legacy
     P2SHWPKH,       // Legacy Segwit
     P2WPKH,         // Segwit
+    P2TR,           // Taproot
+}
+
+struct BitcoinDescriptor {
+    address_type: AddressType,
+    xpub_key: Xpub,
+    derivation_path: DerivationPath,
+}
+
+fn address_for_derivation_path<C: secp256k1::Verification>(
+    secp: &Secp256k1<C>,
+    xpub_key: &Xpub,
+    derivation_path: &DerivationPath,
+    address_type: AddressType,
+) -> Result<Address> {
+    let key = xpub_key.derive_pub(secp, derivation_path)?;
+    let address = match address_type {
+        AddressType::P2PKH => Address::p2pkh(&key.to_pub(), Network::Bitcoin),
+        AddressType::P2SHWPKH => Address::p2shwpkh(&key.to_pub(), Network::Bitcoin),
+        AddressType::P2WPKH => Address::p2wpkh(&key.to_pub(), Network::Bitcoin),
+        AddressType::P2TR => Address::p2tr(secp, key.to_x_only_pub(), None, Network::Bitcoin),
+    };
+    Ok(address)
 }
 
 async fn scan_children<C: secp256k1::Verification>(
@@ -142,12 +165,7 @@ async fn scan_children<C: secp256k1::Verification>(
     let mut empty_addresses = 0;
 
     for child in iter.by_ref() {
-        let key = xpub_key.derive_pub(secp, &child)?.to_pub();
-        let address = match address_type {
-            AddressType::P2PKH => Address::p2pkh(&key, Network::Bitcoin),
-            AddressType::P2SHWPKH => Address::p2shwpkh(&key, Network::Bitcoin),
-            AddressType::P2WPKH => Address::p2wpkh(&key, Network::Bitcoin),
-        };
+        let address = address_for_derivation_path(secp, xpub_key, &child, address_type)?;
 
         println!("  checking address {}: {}", child, address);
 
@@ -174,25 +192,37 @@ async fn scan_children<C: secp256k1::Verification>(
     Ok(())
 }
 
+fn decode_extended_pub_key(extended_pub_key: &str) -> Result<Xpub> {
+    let mut xpub_data = base58::decode_check(extended_pub_key)?;
+    if xpub_data.len() < 4 {
+        bail!("Invalid extended public key");
+    }
+
+    // Replace the version bytes with 0488b21e, this way we can support ypub and zpub.
+    xpub_data[0..4].copy_from_slice(&[0x04, 0x88, 0xb2, 0x1e]);
+    Ok(Xpub::decode(&xpub_data)?)
+}
+
+fn address_type_for_extended_pub_key(extended_pub_key: &str) -> Result<AddressType> {
+    let prefix = extended_pub_key
+        .get(..4)
+        .context("Extended public key is too short")?;
+    match prefix {
+        "xpub" => Ok(AddressType::P2PKH),
+        "ypub" => Ok(AddressType::P2SHWPKH),
+        "zpub" => Ok(AddressType::P2WPKH),
+        _ => bail!("Unsupported extended public key prefix {}", prefix),
+    }
+}
+
 async fn xpub_addresses_and_txs<C: secp256k1::Verification>(
     client: &AsyncClient,
     secp: &Secp256k1<C>,
     xpub: &str,
     address_transactions: &mut HashMap<Address, Result<Vec<Tx>>>,
 ) -> Result<()> {
-    let mut xpub_data = base58::decode_check(xpub)?;
-
-    // replace the version bytes with 0488b21e, this way we can support ypub and zpub
-    xpub_data[0..4].copy_from_slice(&[0x04, 0x88, 0xb2, 0x1e]);
-
-    let xpub_key = Xpub::decode(&xpub_data)?;
-    let xpub_prefix = xpub.split_at(4).0;
-    let address_type = match xpub_prefix {
-        "xpub" => AddressType::P2PKH,
-        "ypub" => AddressType::P2SHWPKH,
-        "zpub" => AddressType::P2WPKH,
-        _ => panic!("unsupported xpub prefix {}", xpub_prefix), // todo: return error instead
-    };
+    let xpub_key = decode_extended_pub_key(xpub)?;
+    let address_type = address_type_for_extended_pub_key(xpub)?;
 
     println!("iterating addresses from xpub {}", xpub);
 
@@ -209,6 +239,84 @@ async fn xpub_addresses_and_txs<C: secp256k1::Verification>(
     Ok(())
 }
 
+fn descriptor_body(descriptor: &str) -> Result<(AddressType, &str)> {
+    let descriptor = descriptor.trim().split_once('#').map_or(descriptor.trim(), |(body, _)| body.trim());
+    if let Some(body) = descriptor.strip_prefix("pkh(").and_then(|body| body.strip_suffix(')')) {
+        return Ok((AddressType::P2PKH, body));
+    }
+    if let Some(body) = descriptor.strip_prefix("sh(wpkh(").and_then(|body| body.strip_suffix("))")) {
+        return Ok((AddressType::P2SHWPKH, body));
+    }
+    if let Some(body) = descriptor.strip_prefix("wpkh(").and_then(|body| body.strip_suffix(')')) {
+        return Ok((AddressType::P2WPKH, body));
+    }
+    if let Some(body) = descriptor.strip_prefix("tr(").and_then(|body| body.strip_suffix(')')) {
+        return Ok((AddressType::P2TR, body));
+    }
+    bail!("Unsupported Bitcoin descriptor");
+}
+
+fn strip_key_origin(key_expression: &str) -> Result<&str> {
+    let key_expression = key_expression.trim();
+    if let Some(rest) = key_expression.strip_prefix('[') {
+        let end = rest.find(']').context("Descriptor key origin is missing closing bracket")?;
+        Ok(&rest[end + 1..])
+    } else {
+        Ok(key_expression)
+    }
+}
+
+fn descriptor_derivation_path(path_suffix: Option<&str>) -> Result<DerivationPath> {
+    let Some(path_suffix) = path_suffix else {
+        return Ok(DerivationPath::master());
+    };
+    let path_prefix = if path_suffix == "*" {
+        ""
+    } else {
+        path_suffix
+            .strip_suffix("/*")
+            .context("Descriptor extended public key path must end in /*")?
+    };
+    if path_prefix.is_empty() {
+        Ok(DerivationPath::master())
+    } else {
+        Ok(DerivationPath::from_str(&format!("m/{}", path_prefix))?)
+    }
+}
+
+fn parse_bitcoin_descriptor(descriptor: &str) -> Result<BitcoinDescriptor> {
+    let (address_type, key_expression) = descriptor_body(descriptor)?;
+    let key_expression = strip_key_origin(key_expression)?;
+    let (extended_pub_key, path_suffix) = match key_expression.split_once('/') {
+        Some((extended_pub_key, path_suffix)) => (extended_pub_key, Some(path_suffix)),
+        None => (key_expression, None),
+    };
+
+    Ok(BitcoinDescriptor {
+        address_type,
+        xpub_key: decode_extended_pub_key(extended_pub_key)?,
+        derivation_path: descriptor_derivation_path(path_suffix)?,
+    })
+}
+
+async fn descriptor_addresses_and_txs<C: secp256k1::Verification>(
+    client: &AsyncClient,
+    secp: &Secp256k1<C>,
+    descriptor: &str,
+    address_transactions: &mut HashMap<Address, Result<Vec<Tx>>>,
+) -> Result<()> {
+    let descriptor = parse_bitcoin_descriptor(descriptor)?;
+    println!("iterating addresses from descriptor");
+    scan_children(
+        client,
+        address_transactions,
+        secp,
+        &descriptor.xpub_key,
+        &descriptor.derivation_path,
+        descriptor.address_type,
+    ).await
+}
+
 pub(crate) async fn xpub_addresses_transactions(
     client: &AsyncClient,
     xpubs: &Vec<String>,
@@ -221,6 +329,31 @@ pub(crate) async fn xpub_addresses_transactions(
     // todo: do in parallel
     for xpub in xpubs {
         xpub_addresses_and_txs(client, &secp, xpub, &mut address_transactions).await?;
+    }
+
+    let mut pub_keys = HashSet::new();
+    pub_keys.extend(address_transactions.iter().filter_map(|(address, txs)| {
+        match txs {
+            Ok(txs) if !txs.is_empty() => Some(address.script_pubkey()),
+            _ => None,
+        }
+    }));
+
+    println!("collected {} active addresses (scanned {})", pub_keys.len(), address_transactions.len());
+
+    Ok(process_transactions(address_transactions, pub_keys))
+}
+
+pub(crate) async fn descriptor_addresses_transactions(
+    client: &AsyncClient,
+    descriptors: &Vec<String>,
+) -> Result<Vec<Transaction>> {
+    let secp = Secp256k1::new();
+
+    let mut address_transactions: HashMap<Address, Result<Vec<Tx>>> = HashMap::new();
+
+    for descriptor in descriptors {
+        descriptor_addresses_and_txs(client, &secp, descriptor, &mut address_transactions).await?;
     }
 
     let mut pub_keys = HashSet::new();
@@ -254,6 +387,13 @@ pub(crate) fn load_bitcoin_xpubs_async(source_path: String) -> LoadFuture {
     })
 }
 
+pub(crate) fn load_bitcoin_descriptors_async(source_path: String) -> LoadFuture {
+    Box::pin(async move {
+        let esplora_client = async_esplora_client().unwrap();
+        descriptor_addresses_transactions(&esplora_client, &split_whitespace_owned(&source_path)).await
+    })
+}
+
 #[distributed_slice(crate::TRANSACTION_SOURCES)]
 static BITCOIN_ADDRESSES: TransactionSource = TransactionSource {
     id: "BitcoinAddresses",
@@ -273,6 +413,89 @@ static BITCOIN_XPUBS: TransactionSource = TransactionSource {
     load_sync: None,
     load_async: Some(load_bitcoin_xpubs_async),
 };
+
+#[distributed_slice(crate::TRANSACTION_SOURCES)]
+static BITCOIN_DESCRIPTORS: TransactionSource = TransactionSource {
+    id: "BitcoinDescriptors",
+    label: "Bitcoin Descriptor(s)",
+    csv: &[],
+    detect: None,
+    load_sync: None,
+    load_async: Some(load_bitcoin_descriptors_async),
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::bip32::Xpriv;
+
+    fn account_xpub(path: &str) -> String {
+        let secp = Secp256k1::new();
+        let seed = [7; 32];
+        let master = Xpriv::new_master(Network::Bitcoin, &seed).unwrap();
+        let account = master
+            .derive_priv(&secp, &DerivationPath::from_str(path).unwrap())
+            .unwrap();
+        Xpub::from_priv(&secp, &account).to_string()
+    }
+
+    #[test]
+    fn parses_taproot_descriptor() {
+        let xpub = account_xpub("m/86'/0'/0'");
+        let descriptor = format!("tr([00000000/86'/0'/0']{}/0/*)", xpub);
+
+        let parsed = parse_bitcoin_descriptor(&descriptor).unwrap();
+        assert_eq!(parsed.address_type, AddressType::P2TR);
+        assert_eq!(
+            parsed.derivation_path,
+            DerivationPath::from_str("m/0").unwrap()
+        );
+
+        let secp = Secp256k1::new();
+        let first_path = parsed
+            .derivation_path
+            .child(ChildNumber::Normal { index: 0 });
+        let address = address_for_derivation_path(
+            &secp,
+            &parsed.xpub_key,
+            &first_path,
+            parsed.address_type,
+        ).unwrap();
+
+        assert!(address.to_string().starts_with("bc1p"));
+    }
+
+    #[test]
+    fn parses_wrapped_segwit_descriptor_with_checksum() {
+        let xpub = account_xpub("m/49'/0'/0'");
+        let descriptor = format!("sh(wpkh({}/1/*))#ignored", xpub);
+
+        let parsed = parse_bitcoin_descriptor(&descriptor).unwrap();
+        assert_eq!(parsed.address_type, AddressType::P2SHWPKH);
+        assert_eq!(
+            parsed.derivation_path,
+            DerivationPath::from_str("m/1").unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_descriptor_without_wildcard() {
+        let xpub = account_xpub("m/84'/0'/0'");
+        let descriptor = format!("wpkh({}/0/1)", xpub);
+
+        assert!(parse_bitcoin_descriptor(&descriptor).is_err());
+    }
+
+    #[test]
+    fn parses_descriptor_with_direct_wildcard() {
+        let xpub = account_xpub("m/84'/0'/0'");
+        let descriptor = format!("wpkh({}/*)", xpub);
+
+        let parsed = parse_bitcoin_descriptor(&descriptor).unwrap();
+        assert_eq!(parsed.address_type, AddressType::P2WPKH);
+        assert_eq!(parsed.derivation_path, DerivationPath::master());
+    }
+}
 
 // Converts the transactions, using a set of tx_hash to skip duplicates
 fn process_transactions(address_transactions: HashMap<Address, Result<Vec<Tx>>>, pub_keys: HashSet<ScriptBuf>) -> Vec<Transaction> {


### PR DESCRIPTION
Refs #76.

Summary:
- Add parser support for Bitcoin output descriptors: `pkh(...)`, `sh(wpkh(...))`, `wpkh(...)`, and key-path `tr(...)`.
- Derive descriptor child addresses from xpub expressions ending in `/*`, including taproot `bc1p...` addresses.
- Keep existing xpub/ypub/zpub source behavior intact while returning errors for unsupported prefixes instead of panicking.
- Add a Bitcoin Descriptor(s) source in the add-source UI and mention output descriptors in the README.
- Add tests for taproot descriptors, wrapped segwit descriptors with checksums, direct wildcard descriptors, and invalid non-wildcard descriptors.

Tests:
- `env CARGO_HOME=/private/tmp/raccoin-76-cargo-home cargo test`
- `git diff --check`

Payout address: BTC `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`
