### PR TITLE
Add generic CSV and JSON import assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Raccoin can import CSV files exported from the following sources:
 Raccoin can also create a reusable CSV/JSON mapping for other sources using the
 CSV/JSON Assistant in the Add Source dialog. The assistant saves the mapping as
 a `.raccoin-import.json` file, which can be added again or shared along with the
-source file.
+source file. Statement exports with a single signed balance-change column can
+map that column to both the received and sent amount fields, letting positive
+values import as incoming transactions and negative values as outgoing ones.
 
 ### Blockchains
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Raccoin can import CSV files exported from the following sources:
 * [Wallet of Satoshi](https://walletofsatoshi.com/) (mobile wallet)
 * [wave.space](https://www.wave.space/) (Bitcoin crypto card)
 
+Raccoin can also create a reusable CSV/JSON mapping for other sources using the
+CSV/JSON Assistant in the Add Source dialog. The assistant saves the mapping as
+a `.raccoin-import.json` file, which can be added again or shared along with the
+source file.
+
 ### Blockchains
 
 Raccoin can also synchronize wallets from certain blockchains directly. Supported are:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,9 @@ to your wallet, now add a source. The UI can add CSV and JSON files in
 If your file format is not built in, choose the CSV/JSON Assistant and map the
 timestamp, transaction type, amount, currency, fee and description fields. The
 assistant saves this mapping as a `.raccoin-import.json` file that can be reused
-or shared.
+or shared. For statement exports that use one signed change column, map that
+column to both the received and sent amount fields and map its asset column to
+both currency fields.
 
 ## See Balances and Transactions
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,13 +32,13 @@ subset of the relavant transactions.
 ## Add a Source
 
 A wallet is just a name for a group of transaction sources. To add transactions
-to your wallet, now add a source. Currently, the UI only allows adding CSV files
-in [various formats](/reference). The format of the CSV file will be auto-detected.
+to your wallet, now add a source. The UI can add CSV and JSON files in
+[various formats](/reference). Built-in source formats are auto-detected.
 
-> If your specific CSV file format is not supported, please [open an
-> issue](https://github.com/bjorn/raccoin/issues) describing the contents of
-> that file and its origins! It is usually very easy to add support for
-> additional formats.
+If your file format is not built in, choose the CSV/JSON Assistant and map the
+timestamp, transaction type, amount, currency, fee and description fields. The
+assistant saves this mapping as a `.raccoin-import.json` file that can be reused
+or shared.
 
 ## See Balances and Transactions
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,6 +39,22 @@ Raccoin can import CSV files exported from the following sources:
 > that file and its origins. It is usually very easy to add support for
 > additional formats!
 
+### Generic CSV/JSON Mapping
+
+For CSV or JSON files that do not match a built-in source, use the CSV/JSON
+Assistant from the Add Source dialog. The assistant lets you map fields for the
+timestamp, transaction type, received and sent amounts, currencies, fees, fiat
+value, transaction ID, note and blockchain.
+
+Transaction type values such as `buy`, `sell`, `deposit` and `withdrawal` can be
+mapped to Raccoin transaction types in the same dialog. Date/time parsing uses a
+configurable format, with several common formats tried as fallbacks.
+
+The assistant stores the mapping in a `.raccoin-import.json` file next to the
+source file. This mapping file can be added again through the normal CSV/JSON
+file picker, and it can be shared with another Raccoin user together with the
+same source-file layout.
+
 ### Blockchains
 
 Raccoin can also synchronize wallets from certain blockchains directly.
@@ -55,9 +71,8 @@ Supported are:
 
 ### JSON Format
 
-> There is currently no way to import transactions exported to JSON from the UI,
-> but you can add them by manually adding a snippet to the portfolio JSON file,
-> similar to above:
+Transactions exported from Raccoin can be imported again through the CSV/JSON
+file picker. They can also be added manually to the portfolio JSON file:
 > ```json
 > "sources": [
 >   {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -49,6 +49,11 @@ value, transaction ID, note and blockchain.
 Transaction type values such as `buy`, `sell`, `deposit` and `withdrawal` can be
 mapped to Raccoin transaction types in the same dialog. Date/time parsing uses a
 configurable format, with several common formats tried as fallbacks.
+For account-statement exports with one signed balance-change column, such as
+Binance files containing `UTC_Time`, `Operation`, `Coin`, `Change` and `Remark`,
+map the same `Change` and `Coin` columns to both the received and sent fields.
+Positive changes become incoming transactions and negative changes become
+outgoing transactions.
 
 The assistant stores the mapping in a `.raccoin-import.json` file next to the
 source file. This mapping file can be added again through the normal CSV/JSON

--- a/raccoin_ui/ui/appwindow.slint
+++ b/raccoin_ui/ui/appwindow.slint
@@ -1,4 +1,4 @@
-import { Button, CheckBox, ComboBox, GridBox, HorizontalBox, LineEdit, StandardButton, VerticalBox } from "std-widgets.slint";
+import { Button, CheckBox, ComboBox, GridBox, HorizontalBox, LineEdit, ScrollView, StandardButton, VerticalBox } from "std-widgets.slint";
 import { Portfolio } from "portfolio.slint";
 import { Wallets } from "wallets.slint";
 import { Transactions } from "transactions.slint";
@@ -192,9 +192,11 @@ component AddWalletSourceDialog inherits Rectangle {
 
     callback close-requested();
     callback add-csv-requested(int);
+    callback start-generic-import-requested(int);
+    callback save-generic-import-requested(int);
     callback add-address-requested(int, string, string, string);
 
-    preferred-height: self.step == 0 ? page-1.preferred-height : page-2.preferred-height;
+    preferred-height: self.step == 0 ? page-1.preferred-height : self.step == 1 ? page-2.preferred-height : page-3.preferred-height;
     min-height: 0px;
 
     function select-kind(kind_id: string, kind_label: string) {
@@ -210,12 +212,12 @@ component AddWalletSourceDialog inherits Rectangle {
 
         Text {
             row: 0; col: 0;
-            text: "Import CSV file";
+            text: "Known source";
             vertical-alignment: center;
         }
         Button {
             row: 0; col: 1; colspan: 2;
-            text: "CSV file";
+            text: "CSV/JSON File";
             clicked => {
                 root.add-csv-requested(wallet-index);
                 root.close-requested();
@@ -223,40 +225,57 @@ component AddWalletSourceDialog inherits Rectangle {
         }
 
         Text {
-            row: 2; col: 0;
+            row: 1; col: 0;
+            text: "Custom import";
+            vertical-alignment: center;
+        }
+        Button {
+            row: 1; col: 1; colspan: 2;
+            text: "CSV/JSON Assistant";
+            clicked => {
+                Facade.generic-import-source-path = "";
+                root.start-generic-import-requested(wallet-index);
+                if (Facade.generic-import-source-path != "") {
+                    root.step = 2;
+                }
+            }
+        }
+
+        Text {
+            row: 3; col: 0;
             text: "Bitcoin";
             vertical-alignment: center;
 
         }
         Button {
-            row: 2; col: 1;
+            row: 3; col: 1;
             text: "Bitcoin Address(es)";
             clicked => { root.select-kind("BitcoinAddresses", "Bitcoin Address(es)"); }
         }
         Button {
-            row: 2; col: 2;
+            row: 3; col: 2;
             text: "Bitcoin HD Wallet(s)";
             clicked => { root.select-kind("BitcoinXpubs", "Bitcoin HD Wallet(s)"); }
         }
 
         Text {
-            row: 3; col: 0;
+            row: 4; col: 0;
             text: "Ethereum";
             vertical-alignment: TextVerticalAlignment.center;
         }
         Button {
-            row: 3; col: 1; colspan: 2;
+            row: 4; col: 1; colspan: 2;
             text: "Ethereum Address";
             clicked => { root.select-kind("EthereumAddress", "Ethereum Address"); }
         }
 
         Text {
-            row: 4; col: 0;
+            row: 5; col: 0;
             text: "Stellar";
             vertical-alignment: TextVerticalAlignment.center;
         }
         Button {
-            row: 4; col: 1; colspan: 2;
+            row: 5; col: 1; colspan: 2;
             text: "Stellar Account";
             clicked => { root.select-kind("StellarAccount", "Stellar Address"); }
         }
@@ -330,6 +349,173 @@ component AddWalletSourceDialog inherits Rectangle {
                 clicked => {
                     root.add-address-requested(wallet-index, kind-id, address-input.text, name);
                     root.close-requested();
+                }
+            }
+        }
+    }
+
+    page-3 := ScrollView {
+        visible: step == 2;
+        preferred-height: 560px;
+        min-height: 0px;
+
+        generic-form := VerticalBox {
+            padding-left: 4px;
+            padding-right: 4px;
+            spacing: 8px;
+
+            Text {
+                text: Facade.generic-import-source-path;
+                color: #999;
+                font-size: 12px;
+            }
+
+            GridBox {
+                Text { row: 0; col: 0; text: "Source Name"; vertical-alignment: center; }
+                LineEdit {
+                    row: 0; col: 1;
+                    text <=> Facade.generic-import-name;
+                    placeholder-text: "Optional source name";
+                }
+
+                Text { row: 1; col: 0; text: "Timestamp"; vertical-alignment: center; }
+                ComboBox {
+                    row: 1; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-timestamp-column;
+                }
+
+                Text { row: 2; col: 0; text: "Date Format"; vertical-alignment: center; }
+                LineEdit {
+                    row: 2; col: 1;
+                    text <=> Facade.generic-import-date-format;
+                    placeholder-text: "%Y-%m-%d %H:%M:%S";
+                }
+
+                Text { row: 3; col: 0; text: "Transaction Type"; vertical-alignment: center; }
+                ComboBox {
+                    row: 3; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-type-column;
+                }
+
+                Text { row: 4; col: 0; text: "Received Amount"; vertical-alignment: center; }
+                ComboBox {
+                    row: 4; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-received-amount-column;
+                }
+
+                Text { row: 5; col: 0; text: "Received Currency"; vertical-alignment: center; }
+                ComboBox {
+                    row: 5; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-received-currency-column;
+                }
+
+                Text { row: 6; col: 0; text: "Sent Amount"; vertical-alignment: center; }
+                ComboBox {
+                    row: 6; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-sent-amount-column;
+                }
+
+                Text { row: 7; col: 0; text: "Sent Currency"; vertical-alignment: center; }
+                ComboBox {
+                    row: 7; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-sent-currency-column;
+                }
+
+                Text { row: 8; col: 0; text: "Fee Amount"; vertical-alignment: center; }
+                ComboBox {
+                    row: 8; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-fee-amount-column;
+                }
+
+                Text { row: 9; col: 0; text: "Fee Currency"; vertical-alignment: center; }
+                ComboBox {
+                    row: 9; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-fee-currency-column;
+                }
+
+                Text { row: 10; col: 0; text: "Fiat Value"; vertical-alignment: center; }
+                ComboBox {
+                    row: 10; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-value-amount-column;
+                }
+
+                Text { row: 11; col: 0; text: "Fiat Currency"; vertical-alignment: center; }
+                ComboBox {
+                    row: 11; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-value-currency-column;
+                }
+
+                Text { row: 12; col: 0; text: "Transaction ID"; vertical-alignment: center; }
+                ComboBox {
+                    row: 12; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-tx-hash-column;
+                }
+
+                Text { row: 13; col: 0; text: "Note"; vertical-alignment: center; }
+                ComboBox {
+                    row: 13; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-description-column;
+                }
+
+                Text { row: 14; col: 0; text: "Blockchain"; vertical-alignment: center; }
+                ComboBox {
+                    row: 14; col: 1;
+                    model: Facade.generic-import-fields;
+                    current-value <=> Facade.generic-import-blockchain-column;
+                }
+            }
+
+            Text {
+                text: "Transaction type values";
+                font-weight: 600;
+            }
+
+            GridBox {
+                Text { row: 0; col: 0; text: "Buy"; vertical-alignment: center; }
+                LineEdit { row: 0; col: 1; text <=> Facade.generic-import-buy-values; }
+                Text { row: 1; col: 0; text: "Sell"; vertical-alignment: center; }
+                LineEdit { row: 1; col: 1; text <=> Facade.generic-import-sell-values; }
+                Text { row: 2; col: 0; text: "Receive"; vertical-alignment: center; }
+                LineEdit { row: 2; col: 1; text <=> Facade.generic-import-receive-values; }
+                Text { row: 3; col: 0; text: "Send"; vertical-alignment: center; }
+                LineEdit { row: 3; col: 1; text <=> Facade.generic-import-send-values; }
+                Text { row: 4; col: 0; text: "Income"; vertical-alignment: center; }
+                LineEdit { row: 4; col: 1; text <=> Facade.generic-import-income-values; }
+                Text { row: 5; col: 0; text: "Expense"; vertical-alignment: center; }
+                LineEdit { row: 5; col: 1; text <=> Facade.generic-import-expense-values; }
+                Text { row: 6; col: 0; text: "Fee"; vertical-alignment: center; }
+                LineEdit { row: 6; col: 1; text <=> Facade.generic-import-fee-values; }
+            }
+
+            HorizontalBox {
+                padding: 0;
+
+                Button {
+                    text: "Back";
+                    clicked => {
+                        root.step = 0;
+                    }
+                }
+                Rectangle { horizontal-stretch: 1; }
+                Button {
+                    text: "Add Source";
+                    enabled: Facade.generic-import-timestamp-column != "";
+                    clicked => {
+                        root.save-generic-import-requested(wallet-index);
+                        root.close-requested();
+                    }
                 }
             }
         }
@@ -421,7 +607,7 @@ component MainContent inherits Rectangle {
         width: root.width;
         height: root.height;
 
-        title: root.add-source-step == 0 ? "Add Source" : "Add " + root.add-source-kind-label;
+        title: root.add-source-step == 0 ? "Add Source" : root.add-source-step == 2 ? "Map Import Fields" : "Add " + root.add-source-kind-label;
 
         AddWalletSourceDialog {
             wallet-index <=> root.add-source-wallet-index;
@@ -433,6 +619,8 @@ component MainContent inherits Rectangle {
 
             close-requested() => { add-source-modal.close(); }
             add-csv-requested(wallet_index) => { Facade.add-source-csv(wallet_index); }
+            start-generic-import-requested(wallet_index) => { Facade.start-generic-import(wallet_index); }
+            save-generic-import-requested(wallet_index) => { Facade.save-generic-import(wallet_index); }
             add-address-requested(wallet_index, kind_id, input, name) => {
                 Facade.add-source-address(wallet_index, kind_id, input, name);
             }

--- a/raccoin_ui/ui/global.slint
+++ b/raccoin_ui/ui/global.slint
@@ -18,6 +18,7 @@ export global Facade {
     in-out property <[UiWallet]> wallets: TestData.wallets;
     in-out property <[UiWalletSource]> sources: TestData.sources;
     in-out property <[string]> source-types;
+    in-out property <[string]> generic-import-fields;
     in-out property <[UiTransaction]> transactions: TestData.transactions;
     in-out property <int> transaction-warning-count: 0;
     in-out property <[StandardListViewItem]> report-years: TestData.report-years;
@@ -38,6 +39,32 @@ export global Facade {
     in-out property <string> app-homepage: "";
     in-out property <string> app-license: "";
 
+    in-out property <string> generic-import-source-path: "";
+    in-out property <string> generic-import-format: "csv";
+    in-out property <string> generic-import-delimiter: ",";
+    in-out property <string> generic-import-name: "";
+    in-out property <string> generic-import-date-format: "%Y-%m-%d %H:%M:%S";
+    in-out property <string> generic-import-timestamp-column: "";
+    in-out property <string> generic-import-type-column: "";
+    in-out property <string> generic-import-received-amount-column: "";
+    in-out property <string> generic-import-received-currency-column: "";
+    in-out property <string> generic-import-sent-amount-column: "";
+    in-out property <string> generic-import-sent-currency-column: "";
+    in-out property <string> generic-import-fee-amount-column: "";
+    in-out property <string> generic-import-fee-currency-column: "";
+    in-out property <string> generic-import-value-amount-column: "";
+    in-out property <string> generic-import-value-currency-column: "";
+    in-out property <string> generic-import-tx-hash-column: "";
+    in-out property <string> generic-import-description-column: "";
+    in-out property <string> generic-import-blockchain-column: "";
+    in-out property <string> generic-import-buy-values: "";
+    in-out property <string> generic-import-sell-values: "";
+    in-out property <string> generic-import-receive-values: "";
+    in-out property <string> generic-import-send-values: "";
+    in-out property <string> generic-import-income-values: "";
+    in-out property <string> generic-import-expense-values: "";
+    in-out property <string> generic-import-fee-values: "";
+
     // ACTIONS
 
     callback new-portfolio();
@@ -51,6 +78,8 @@ export global Facade {
     callback remove-wallet(int);
 
     callback add-source-csv(int);
+    callback start-generic-import(int);
+    callback save-generic-import(int);
     callback add-source-address(int, string, string, string);
     callback remove-source(int,int);
 

--- a/src/binance.rs
+++ b/src/binance.rs
@@ -1,11 +1,15 @@
 use std::path::Path;
 
 use anyhow::Result;
-use chrono::{NaiveDateTime, NaiveDate, NaiveTime};
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
-use crate::{time::deserialize_date_time, base::{Amount, Transaction, self, deserialize_amount}, CsvSpec, TransactionSource};
+use crate::{
+    base::{self, deserialize_amount, Amount, Transaction},
+    time::deserialize_date_time,
+    CsvSpec, TransactionSource,
+};
 use linkme::distributed_slice;
 
 // #[derive(Debug, Deserialize)]
@@ -21,9 +25,16 @@ enum Operation {
     Withdraw,
     #[serde(rename = "Transfer Between Main and Funding Wallet")]
     Transfer,
+    #[serde(rename = "transfer_in", alias = "Transfer In")]
+    TransferIn,
+    #[serde(rename = "transfer_out", alias = "Transfer Out")]
+    TransferOut,
     #[serde(rename = "Binance Convert")]
     Convert,
-    #[serde(rename = "Small Assets Exchange BNB")]
+    #[serde(
+        rename = "Small Assets Exchange BNB",
+        alias = "Small assets exchange BNB"
+    )]
     SmallAssetsExchange,
     #[serde(rename = "Fiat Deposit")]
     FiatDeposit,
@@ -35,6 +46,25 @@ enum Operation {
     CardSpending,
     #[serde(rename = "Airdrop Assets")]
     Airdrop,
+    #[serde(rename = "Pool Distribution")]
+    PoolDistribution,
+    #[serde(rename = "Referrer rebates", alias = "Referrer Rebate")]
+    ReferrerRebate,
+    #[serde(rename = "Commission History")]
+    CommissionHistory,
+    #[serde(rename = "Commission Rebate")]
+    CommissionRebate,
+    #[serde(rename = "ETH 2.0 Staking Rewards")]
+    EthStakingRewards,
+    #[serde(rename = "Savings Interest")]
+    SavingsInterest,
+    #[serde(
+        rename = "Savings Principal redemption",
+        alias = "POS savings redemption"
+    )]
+    SavingsPrincipalRedemption,
+    #[serde(rename = "Savings purchase", alias = "POS savings purchase")]
+    SavingsPurchase,
     #[serde(rename = "Transaction Fee", alias = "Fee")]
     TransactionFee,
     #[serde(rename = "Transaction Buy", alias = "Buy")]
@@ -45,6 +75,8 @@ enum Operation {
     TransactionSold,
     #[serde(rename = "Transaction Revenue")]
     TransactionRevenue,
+    #[serde(rename = "Transaction Related")]
+    TransactionRelated,
 }
 
 // struct for storing the following CSV columns:
@@ -119,7 +151,14 @@ fn normalize_currency(timestamp: NaiveDateTime, currency: String) -> String {
         "NANO" => "XNO".to_owned(),
         // rename LUNA to LUNC if it is mentioned before the rename that happened between 2022-05-26 and 2022-05-30
         // https://www.binance.com/en/support/announcement/binance-will-list-terra-2-0-luna-in-the-innovation-zone-luna-old-renamed-as-lunc-d044a6742e484b77a170111460b0eed3
-        "LUNA" if timestamp < NaiveDate::from_ymd_opt(2022, 5, 27).unwrap().and_time(NaiveTime::MIN) => "LUNC".to_owned(),
+        "LUNA"
+            if timestamp
+                < NaiveDate::from_ymd_opt(2022, 5, 27)
+                    .unwrap()
+                    .and_time(NaiveTime::MIN) =>
+        {
+            "LUNC".to_owned()
+        }
         _ => currency,
     }
 }
@@ -145,8 +184,11 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
 
     fn try_from(item: BinanceTransactionRecord) -> Result<Self, Self::Error> {
         // https://www.binance.com/en/support/announcement/binance-will-update-the-ticker-of-nano-to-xno-3dc8f6de281f4781a246a1658a21cb80
-        if item.operation == Operation::Distribution && (item.coin == "NANO" || item.coin == "XNO") {
-            return Err(ConversionError::IgnoreReason("Ignored NANO -> XNO conversion"));
+        if item.operation == Operation::Distribution && (item.coin == "NANO" || item.coin == "XNO")
+        {
+            return Err(ConversionError::IgnoreReason(
+                "Ignored NANO -> XNO conversion",
+            ));
         }
 
         let currency = normalize_currency(item.timestamp, item.coin);
@@ -154,13 +196,19 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
         // Depending on the operation we expect a negative or positive amount,
         // for others we can expect either. Raise an error otherwise.
         let amount = match item.operation {
-            Operation::Distribution |
-            Operation::Deposit |
-            Operation::FiatDeposit |
-            Operation::CardCashback |
-            Operation::Airdrop |
-            Operation::TransactionBuy |
-            Operation::TransactionRevenue => {
+            Operation::Distribution
+            | Operation::Deposit
+            | Operation::FiatDeposit
+            | Operation::CardCashback
+            | Operation::Airdrop
+            | Operation::PoolDistribution
+            | Operation::ReferrerRebate
+            | Operation::CommissionHistory
+            | Operation::CommissionRebate
+            | Operation::EthStakingRewards
+            | Operation::SavingsInterest
+            | Operation::TransactionBuy
+            | Operation::TransactionRevenue => {
                 if item.change > Decimal::ZERO {
                     Ok(Amount::new(item.change, currency))
                 } else {
@@ -168,11 +216,11 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
                 }
             }
 
-            Operation::Withdraw |
-            Operation::FiatWithdrawal |
-            Operation::TransactionFee |
-            Operation::TransactionSpend |
-            Operation::TransactionSold => {
+            Operation::Withdraw
+            | Operation::FiatWithdrawal
+            | Operation::TransactionFee
+            | Operation::TransactionSpend
+            | Operation::TransactionSold => {
                 if item.change < Decimal::ZERO {
                     Ok(Amount::new(-item.change, currency))
                 } else {
@@ -180,25 +228,45 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
                 }
             }
 
-            Operation::Transfer |
-            Operation::Convert |
-            Operation::SmallAssetsExchange |
-            Operation::CardSpending => {
-                Ok(Amount::new(item.change.abs(), currency))
-            }
+            Operation::Transfer
+            | Operation::TransferIn
+            | Operation::TransferOut
+            | Operation::Convert
+            | Operation::SmallAssetsExchange
+            | Operation::CardSpending
+            | Operation::SavingsPrincipalRedemption
+            | Operation::SavingsPurchase
+            | Operation::TransactionRelated => Ok(Amount::new(item.change.abs(), currency)),
         }?;
 
         let operation = match item.operation {
             Operation::Distribution => Ok(base::Operation::ChainSplit(amount)),
             Operation::Airdrop => Ok(base::Operation::Airdrop(amount)),
+            Operation::PoolDistribution
+            | Operation::EthStakingRewards
+            | Operation::SavingsInterest => Ok(base::Operation::Staking(amount)),
+            Operation::ReferrerRebate | Operation::CommissionHistory => {
+                Ok(base::Operation::Income(amount))
+            }
+            Operation::CommissionRebate => Ok(base::Operation::Cashback(amount)),
             Operation::Deposit => Ok(base::Operation::Receive(amount)),
             Operation::Withdraw => Ok(base::Operation::Send(amount)),
-            Operation::Transfer => Err(ConversionError::IgnoreReason("'Transfer Between Main and Funding Wallet' ignored")),
+            Operation::Transfer
+            | Operation::TransferIn
+            | Operation::TransferOut
+            | Operation::SavingsPrincipalRedemption
+            | Operation::SavingsPurchase => Err(ConversionError::IgnoreReason(
+                "Internal Binance account movement ignored",
+            )),
             Operation::Convert => {
                 if item.change > Decimal::ZERO {
-                    Err(ConversionError::IncompleteConvert(base::Operation::Receive(amount)))
+                    Err(ConversionError::IncompleteConvert(
+                        base::Operation::Receive(amount),
+                    ))
                 } else {
-                    Err(ConversionError::IncompleteConvert(base::Operation::Send(amount)))
+                    Err(ConversionError::IncompleteConvert(base::Operation::Send(
+                        amount,
+                    )))
                 }
             }
             Operation::SmallAssetsExchange => {
@@ -213,7 +281,8 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
             Operation::FiatWithdrawal => Ok(base::Operation::FiatWithdrawal(amount)),
             Operation::CardCashback => Ok(base::Operation::Cashback(amount)),
             Operation::CardSpending => {
-                if item.change > Decimal::ZERO {    // pay-in, likely a refund
+                if item.change > Decimal::ZERO {
+                    // pay-in, likely a refund
                     if amount.is_fiat() {
                         Ok(base::Operation::FiatDeposit(amount))
                     } else {
@@ -223,11 +292,14 @@ impl TryFrom<BinanceTransactionRecord> for Transaction {
                     Ok(base::Operation::Expense(amount))
                 }
             }
-            Operation::TransactionFee |
-            Operation::TransactionBuy |
-            Operation::TransactionSpend |
-            Operation::TransactionSold |
-            Operation::TransactionRevenue => Err(ConversionError::IgnoreReason("Trade related entries are loaded from trade export")),
+            Operation::TransactionFee
+            | Operation::TransactionBuy
+            | Operation::TransactionSpend
+            | Operation::TransactionSold
+            | Operation::TransactionRevenue
+            | Operation::TransactionRelated => Err(ConversionError::IgnoreReason(
+                "Trade related entries are loaded from trade export",
+            )),
         }?;
 
         let mut tx = Transaction::new(item.timestamp, operation);
@@ -265,8 +337,7 @@ impl From<BinanceConvert> for Transaction {
 fn load_binance_transaction_records_csv(input_path: &Path) -> Result<Vec<Transaction>> {
     let mut transactions = Vec::new();
 
-    let mut rdr = csv::ReaderBuilder::new()
-        .from_path(input_path)?;
+    let mut rdr = csv::ReaderBuilder::new().from_path(input_path)?;
 
     let mut incomplete_convert: Option<base::Operation> = None;
 
@@ -278,19 +349,36 @@ fn load_binance_transaction_records_csv(input_path: &Path) -> Result<Vec<Transac
             Err(err) => match err {
                 ConversionError::IncompleteConvert(operation) => {
                     match (&mut incomplete_convert, operation) {
-                        (Some(base::Operation::Receive(incoming)), base::Operation::Send(outgoing)) => {
-                            transactions.push(Transaction::trade(timestamp, incoming.clone(), outgoing));
+                        (
+                            Some(base::Operation::Receive(incoming)),
+                            base::Operation::Send(outgoing),
+                        ) => {
+                            transactions.push(Transaction::trade(
+                                timestamp,
+                                incoming.clone(),
+                                outgoing,
+                            ));
                             incomplete_convert = None;
-                        },
-                        (Some(base::Operation::Send(outgoing)), base::Operation::Receive(incoming)) => {
-                            transactions.push(Transaction::trade(timestamp, incoming, outgoing.clone()));
+                        }
+                        (
+                            Some(base::Operation::Send(outgoing)),
+                            base::Operation::Receive(incoming),
+                        ) => {
+                            transactions.push(Transaction::trade(
+                                timestamp,
+                                incoming,
+                                outgoing.clone(),
+                            ));
                             incomplete_convert = None;
-                        },
+                        }
                         (None, operation) if operation.is_send() || operation.is_receive() => {
                             incomplete_convert = Some(operation);
                         }
                         (_, operation) => {
-                            println!("Error handling incomplete convert with operation: {:?}", operation);
+                            println!(
+                                "Error handling incomplete convert with operation: {:?}",
+                                operation
+                            );
                         }
                     }
                 }
@@ -298,12 +386,15 @@ fn load_binance_transaction_records_csv(input_path: &Path) -> Result<Vec<Transac
                 ConversionError::InvalidValue(operation, change) => {
                     println!("Unexpected 'change' value for {:?}: {:}", operation, change);
                 }
-            }
+            },
         }
     }
 
     if let Some(operation) = incomplete_convert {
-        println!("Error: remaining incomplete convert with operation: {:?}", operation);
+        println!(
+            "Error: remaining incomplete convert with operation: {:?}",
+            operation
+        );
     }
 
     Ok(transactions)
@@ -312,8 +403,7 @@ fn load_binance_transaction_records_csv(input_path: &Path) -> Result<Vec<Transac
 fn load_binance_spot_trades_csv(input_path: &Path) -> Result<Vec<Transaction>> {
     let mut transactions = Vec::new();
 
-    let mut rdr = csv::ReaderBuilder::new()
-        .from_path(input_path)?;
+    let mut rdr = csv::ReaderBuilder::new().from_path(input_path)?;
 
     for result in rdr.deserialize() {
         let record: BinanceSpotTrade = result?;
@@ -327,8 +417,7 @@ fn load_binance_spot_trades_csv(input_path: &Path) -> Result<Vec<Transaction>> {
 fn load_binance_convert_csv(input_path: &Path) -> Result<Vec<Transaction>> {
     let mut transactions = Vec::new();
 
-    let mut rdr = csv::ReaderBuilder::new()
-        .from_path(input_path)?;
+    let mut rdr = csv::ReaderBuilder::new().from_path(input_path)?;
 
     for result in rdr.deserialize() {
         let record: BinanceConvert = result?;
@@ -389,3 +478,80 @@ static BINANCE_TRANSACTION_HISTORY_CSV: TransactionSource = TransactionSource {
     load_sync: Some(load_binance_transaction_records_csv),
     load_async: None,
 };
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use rust_decimal_macros::dec;
+
+    use super::*;
+    use crate::base::Operation as BaseOperation;
+
+    fn temp_csv(name: &str, contents: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "raccoin-binance-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn loads_additional_binance_statement_operations() {
+        let csv_path = temp_csv(
+            "binance-statement.csv",
+            "User_ID,UTC_Time,Account,Operation,Coin,Change,Remark\n\
+             1,2024-03-04 05:06:07,USDT-Futures,Referrer rebates,USDT,1.5,referral\n\
+             1,2024-03-05 05:06:07,Spot,Commission Rebate,BNB,0.02,rebate\n\
+             1,2024-03-06 05:06:07,Spot,ETH 2.0 Staking Rewards,ETH,0.03,staking\n\
+             1,2024-03-07 05:06:07,Spot,Savings Interest,USDT,0.04,savings interest\n\
+             1,2024-03-08 05:06:07,Pool,Pool Distribution,BUSD,0.05,pool distribution\n\
+             1,2024-03-09 05:06:07,Spot,transfer_in,BTC,1.0,internal in\n\
+             1,2024-03-10 05:06:07,Spot,Savings purchase,USDT,-25,internal savings\n\
+             1,2024-03-11 05:06:07,Spot,Transaction Related,USDT,-10,trade ledger line\n",
+        );
+
+        let txs = load_binance_transaction_records_csv(&csv_path).unwrap();
+
+        assert_eq!(txs.len(), 5);
+        match &txs[0].operation {
+            BaseOperation::Income(amount) => {
+                assert_eq!(amount.quantity, dec!(1.5));
+                assert_eq!(amount.currency, "USDT");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        match &txs[1].operation {
+            BaseOperation::Cashback(amount) => {
+                assert_eq!(amount.quantity, dec!(0.02));
+                assert_eq!(amount.currency, "BNB");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        for (tx, expected_quantity, expected_currency) in [
+            (&txs[2], dec!(0.03), "ETH"),
+            (&txs[3], dec!(0.04), "USDT"),
+            (&txs[4], dec!(0.05), "BUSD"),
+        ] {
+            match &tx.operation {
+                BaseOperation::Staking(amount) => {
+                    assert_eq!(amount.quantity, expected_quantity);
+                    assert_eq!(amount.currency, expected_currency);
+                }
+                operation => panic!("Unexpected operation {operation:?}"),
+            }
+        }
+    }
+}

--- a/src/generic_import.rs
+++ b/src/generic_import.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use linkme::distributed_slice;
 use rust_decimal::Decimal;
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    base::{Amount, Operation, Transaction},
     TransactionSource,
+    base::{Amount, Operation, Transaction},
 };
 
 pub(crate) const CONFIG_KIND: &str = "raccoin-generic-import";
@@ -122,7 +122,7 @@ impl GenericOperationKind {
             "stolen" => Some(Self::Stolen),
             "lost" => Some(Self::Lost),
             "burn" => Some(Self::Burn),
-            "income" | "reward" | "rewards" => Some(Self::Income),
+            "income" | "reward" | "rewards" | "distribution" => Some(Self::Income),
             "airdrop" => Some(Self::Airdrop),
             "staking" | "stake" => Some(Self::Staking),
             "cashback" | "cash-back" => Some(Self::Cashback),
@@ -466,6 +466,8 @@ fn record_to_transaction(
         &config.fields.sent_currency,
         "sent",
     )?;
+    let (incoming, outgoing) =
+        split_shared_signed_amount(record, &config.fields, incoming, outgoing)?;
 
     let operation_kind = operation_kind(record, config, incoming.is_some(), outgoing.is_some())?;
     let operation = operation_kind.into_operation(incoming, outgoing)?;
@@ -511,14 +513,23 @@ fn operation_kind(
         }
 
         return GenericOperationKind::from_builtin_label(&raw_type)
+            .or_else(|| operation_from_amount_direction(has_incoming, has_outgoing))
             .with_context(|| format!("Unmapped transaction type '{}'", raw_type));
     }
 
+    operation_from_amount_direction(has_incoming, has_outgoing)
+        .with_context(|| "Missing transaction type and amount fields")
+}
+
+fn operation_from_amount_direction(
+    has_incoming: bool,
+    has_outgoing: bool,
+) -> Option<GenericOperationKind> {
     match (has_incoming, has_outgoing) {
-        (true, true) => Ok(GenericOperationKind::Trade),
-        (true, false) => Ok(GenericOperationKind::Receive),
-        (false, true) => Ok(GenericOperationKind::Send),
-        (false, false) => bail!("Missing transaction type and amount fields"),
+        (true, true) => Some(GenericOperationKind::Trade),
+        (true, false) => Some(GenericOperationKind::Receive),
+        (false, true) => Some(GenericOperationKind::Send),
+        (false, false) => None,
     }
 }
 
@@ -564,6 +575,52 @@ fn read_amount(
 
     let currency = required_field(record, currency_field, &format!("{label} currency"))?;
     Ok(Some(Amount::new(quantity.abs(), currency)))
+}
+
+fn split_shared_signed_amount(
+    record: &GenericRecord,
+    fields: &GenericImportFields,
+    incoming: Option<Amount>,
+    outgoing: Option<Amount>,
+) -> Result<(Option<Amount>, Option<Amount>)> {
+    if !same_configured_field(&fields.received_amount, &fields.sent_amount)
+        || !same_configured_field(&fields.received_currency, &fields.sent_currency)
+    {
+        return Ok((incoming, outgoing));
+    }
+
+    let Some(quantity_raw) = optional_field(record, &fields.received_amount) else {
+        return Ok((incoming, outgoing));
+    };
+
+    let quantity = parse_decimal(&quantity_raw)
+        .with_context(|| format!("Could not parse signed amount '{}'", quantity_raw))?;
+
+    if quantity > Decimal::ZERO {
+        Ok((incoming, None))
+    } else if quantity < Decimal::ZERO {
+        Ok((None, outgoing))
+    } else {
+        Ok((None, None))
+    }
+}
+
+fn same_configured_field(left: &Option<String>, right: &Option<String>) -> bool {
+    let Some(left) = left
+        .as_deref()
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+    else {
+        return false;
+    };
+    let Some(right) = right
+        .as_deref()
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+    else {
+        return false;
+    };
+    left.eq_ignore_ascii_case(right)
 }
 
 fn parse_decimal(raw: &str) -> Result<Decimal> {
@@ -831,6 +888,62 @@ mod tests {
             }
             operation => panic!("Unexpected operation {operation:?}"),
         }
+    }
+
+    #[test]
+    fn imports_signed_change_statement_rows() {
+        let dir = temp_dir("generic-signed-change");
+        let csv_path = dir.join("binance-statement.csv");
+        let config_path = dir.join("binance-statement.raccoin-import.json");
+        std::fs::write(
+            &csv_path,
+            "User_ID,UTC_Time,Account,Operation,Coin,Change,Remark\n\
+             1,2024-03-04 05:06:07,Spot,Deposit,BTC,0.25,from wallet\n\
+             1,2024-03-05 05:06:07,Spot,Withdraw,ETH,-1.5,to wallet\n\
+             1,2024-03-06 05:06:07,Earn,Distribution,BNB,0.01,earn reward\n",
+        )
+        .unwrap();
+
+        let config = GenericImportConfig {
+            source_file: "binance-statement.csv".to_owned(),
+            fields: GenericImportFields {
+                timestamp: Some("UTC_Time".to_owned()),
+                transaction_type: Some("Operation".to_owned()),
+                received_amount: Some("Change".to_owned()),
+                received_currency: Some("Coin".to_owned()),
+                sent_amount: Some("Change".to_owned()),
+                sent_currency: Some("Coin".to_owned()),
+                description: Some("Remark".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        write_config(&config_path, &config);
+
+        let txs = load_generic_import_config(&config_path).unwrap();
+        assert_eq!(txs.len(), 3);
+        match &txs[0].operation {
+            Operation::Receive(amount) => {
+                assert_eq!(amount.quantity, dec!(0.25));
+                assert_eq!(amount.currency, "BTC");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        match &txs[1].operation {
+            Operation::Send(amount) => {
+                assert_eq!(amount.quantity, dec!(1.5));
+                assert_eq!(amount.currency, "ETH");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        match &txs[2].operation {
+            Operation::Income(amount) => {
+                assert_eq!(amount.quantity, dec!(0.01));
+                assert_eq!(amount.currency, "BNB");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        assert_eq!(txs[2].description.as_deref(), Some("earn reward"));
     }
 
     #[test]

--- a/src/generic_import.rs
+++ b/src/generic_import.rs
@@ -1,0 +1,844 @@
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, NaiveDate, NaiveDateTime};
+use linkme::distributed_slice;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    base::{Amount, Operation, Transaction},
+    TransactionSource,
+};
+
+pub(crate) const CONFIG_KIND: &str = "raccoin-generic-import";
+const DEFAULT_DELIMITER: &str = ",";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum GenericImportFormat {
+    Csv,
+    Json,
+}
+
+impl Default for GenericImportFormat {
+    fn default() -> Self {
+        Self::Csv
+    }
+}
+
+impl GenericImportFormat {
+    pub(crate) fn from_path(path: &Path) -> Self {
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("json") => Self::Json,
+            _ => Self::Csv,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct GenericImportFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) transaction_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) received_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) received_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sent_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sent_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fee_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fee_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) value_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) value_currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tx_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) blockchain: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum GenericOperationKind {
+    Buy,
+    Sell,
+    Trade,
+    Swap,
+    FiatDeposit,
+    FiatWithdrawal,
+    Fee,
+    Receive,
+    Send,
+    ChainSplit,
+    Expense,
+    Stolen,
+    Lost,
+    Burn,
+    Income,
+    Airdrop,
+    Staking,
+    Cashback,
+    IncomingGift,
+    OutgoingGift,
+    Spam,
+}
+
+impl GenericOperationKind {
+    fn from_builtin_label(label: &str) -> Option<Self> {
+        let normalized = normalize_type_value(label);
+        match normalized.as_str() {
+            "buy" | "purchase" => Some(Self::Buy),
+            "sell" | "sale" => Some(Self::Sell),
+            "trade" => Some(Self::Trade),
+            "swap" => Some(Self::Swap),
+            "fiatdeposit" | "fiat-deposit" => Some(Self::FiatDeposit),
+            "fiatwithdrawal" | "fiat-withdrawal" => Some(Self::FiatWithdrawal),
+            "fee" => Some(Self::Fee),
+            "receive" | "received" | "deposit" | "transferin" | "transfer-in" => {
+                Some(Self::Receive)
+            }
+            "send" | "sent" | "withdraw" | "withdrawal" | "transferout" | "transfer-out" => {
+                Some(Self::Send)
+            }
+            "chainsplit" | "chain-split" => Some(Self::ChainSplit),
+            "expense" => Some(Self::Expense),
+            "stolen" => Some(Self::Stolen),
+            "lost" => Some(Self::Lost),
+            "burn" => Some(Self::Burn),
+            "income" | "reward" | "rewards" => Some(Self::Income),
+            "airdrop" => Some(Self::Airdrop),
+            "staking" | "stake" => Some(Self::Staking),
+            "cashback" | "cash-back" => Some(Self::Cashback),
+            "incominggift" | "incoming-gift" | "giftin" | "gift-in" => Some(Self::IncomingGift),
+            "outgoinggift" | "outgoing-gift" | "giftout" | "gift-out" => Some(Self::OutgoingGift),
+            "spam" => Some(Self::Spam),
+            _ => None,
+        }
+    }
+
+    fn into_operation(
+        self,
+        incoming: Option<Amount>,
+        outgoing: Option<Amount>,
+    ) -> Result<Operation> {
+        let incoming_or_outgoing =
+            |incoming: Option<Amount>, outgoing: Option<Amount>, label: &str| -> Result<Amount> {
+                incoming
+                    .or(outgoing)
+                    .with_context(|| format!("Missing amount for {label} operation"))
+            };
+        let outgoing_or_incoming =
+            |outgoing: Option<Amount>, incoming: Option<Amount>, label: &str| -> Result<Amount> {
+                outgoing
+                    .or(incoming)
+                    .with_context(|| format!("Missing amount for {label} operation"))
+            };
+        let both = |incoming: Option<Amount>,
+                    outgoing: Option<Amount>,
+                    label: &str|
+         -> Result<(Amount, Amount)> {
+            let incoming = incoming
+                .with_context(|| format!("Missing received amount for {label} operation"))?;
+            let outgoing =
+                outgoing.with_context(|| format!("Missing sent amount for {label} operation"))?;
+            Ok((incoming, outgoing))
+        };
+
+        Ok(match self {
+            Self::Buy => match (incoming, outgoing) {
+                (Some(incoming), Some(outgoing)) => Operation::Trade { incoming, outgoing },
+                (incoming, outgoing) => {
+                    Operation::Buy(incoming_or_outgoing(incoming, outgoing, "buy")?)
+                }
+            },
+            Self::Sell => match (incoming, outgoing) {
+                (Some(incoming), Some(outgoing)) => Operation::Trade { incoming, outgoing },
+                (incoming, outgoing) => {
+                    Operation::Sell(outgoing_or_incoming(outgoing, incoming, "sell")?)
+                }
+            },
+            Self::Trade => {
+                let (incoming, outgoing) = both(incoming, outgoing, "trade")?;
+                Operation::Trade { incoming, outgoing }
+            }
+            Self::Swap => {
+                let (incoming, outgoing) = both(incoming, outgoing, "swap")?;
+                Operation::Swap { incoming, outgoing }
+            }
+            Self::FiatDeposit => {
+                Operation::FiatDeposit(incoming_or_outgoing(incoming, outgoing, "fiat deposit")?)
+            }
+            Self::FiatWithdrawal => Operation::FiatWithdrawal(outgoing_or_incoming(
+                outgoing,
+                incoming,
+                "fiat withdrawal",
+            )?),
+            Self::Fee => Operation::Fee(outgoing_or_incoming(outgoing, incoming, "fee")?),
+            Self::Receive => {
+                Operation::Receive(incoming_or_outgoing(incoming, outgoing, "receive")?)
+            }
+            Self::Send => Operation::Send(outgoing_or_incoming(outgoing, incoming, "send")?),
+            Self::ChainSplit => {
+                Operation::ChainSplit(incoming_or_outgoing(incoming, outgoing, "chain split")?)
+            }
+            Self::Expense => {
+                Operation::Expense(outgoing_or_incoming(outgoing, incoming, "expense")?)
+            }
+            Self::Stolen => Operation::Stolen(outgoing_or_incoming(outgoing, incoming, "stolen")?),
+            Self::Lost => Operation::Lost(outgoing_or_incoming(outgoing, incoming, "lost")?),
+            Self::Burn => Operation::Burn(outgoing_or_incoming(outgoing, incoming, "burn")?),
+            Self::Income => Operation::Income(incoming_or_outgoing(incoming, outgoing, "income")?),
+            Self::Airdrop => {
+                Operation::Airdrop(incoming_or_outgoing(incoming, outgoing, "airdrop")?)
+            }
+            Self::Staking => {
+                Operation::Staking(incoming_or_outgoing(incoming, outgoing, "staking")?)
+            }
+            Self::Cashback => {
+                Operation::Cashback(incoming_or_outgoing(incoming, outgoing, "cashback")?)
+            }
+            Self::IncomingGift => {
+                Operation::IncomingGift(incoming_or_outgoing(incoming, outgoing, "incoming gift")?)
+            }
+            Self::OutgoingGift => {
+                Operation::OutgoingGift(outgoing_or_incoming(outgoing, incoming, "outgoing gift")?)
+            }
+            Self::Spam => Operation::Spam(incoming_or_outgoing(incoming, outgoing, "spam")?),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct GenericImportConfig {
+    pub(crate) kind: String,
+    pub(crate) version: u32,
+    pub(crate) source_file: String,
+    pub(crate) format: GenericImportFormat,
+    pub(crate) delimiter: String,
+    pub(crate) has_headers: bool,
+    pub(crate) trim: bool,
+    pub(crate) datetime_formats: Vec<String>,
+    pub(crate) fields: GenericImportFields,
+    pub(crate) type_mappings: BTreeMap<String, GenericOperationKind>,
+}
+
+impl Default for GenericImportConfig {
+    fn default() -> Self {
+        Self {
+            kind: CONFIG_KIND.to_owned(),
+            version: 1,
+            source_file: String::new(),
+            format: GenericImportFormat::Csv,
+            delimiter: DEFAULT_DELIMITER.to_owned(),
+            has_headers: true,
+            trim: true,
+            datetime_formats: default_datetime_formats(),
+            fields: GenericImportFields::default(),
+            type_mappings: BTreeMap::new(),
+        }
+    }
+}
+
+pub(crate) struct GenericImportFilePreview {
+    pub(crate) fields: Vec<String>,
+    pub(crate) format: GenericImportFormat,
+    pub(crate) delimiter: String,
+}
+
+pub(crate) fn default_datetime_formats() -> Vec<String> {
+    [
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d",
+        "%d/%m/%Y %H:%M:%S",
+        "%d/%m/%Y %H:%M",
+        "%m/%d/%Y %H:%M:%S",
+        "%m/%d/%Y %H:%M",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect()
+}
+
+pub(crate) fn add_type_mappings(
+    mappings: &mut BTreeMap<String, GenericOperationKind>,
+    raw_values: &str,
+    kind: GenericOperationKind,
+) {
+    for raw_value in raw_values
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        mappings.insert(raw_value.to_owned(), kind);
+    }
+}
+
+pub(crate) fn preview_import_file(path: &Path) -> Result<GenericImportFilePreview> {
+    match GenericImportFormat::from_path(path) {
+        GenericImportFormat::Csv => preview_csv_file(path),
+        GenericImportFormat::Json => preview_json_file(path),
+    }
+}
+
+pub(crate) fn detect_generic_import_config(input_path: &Path) -> Result<bool> {
+    if !input_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+    {
+        return Ok(false);
+    }
+
+    let json = std::fs::read_to_string(input_path)?;
+    let value: Value = serde_json::from_str(&json)?;
+    Ok(value
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| kind == CONFIG_KIND))
+}
+
+pub(crate) fn load_generic_import_config(input_path: &Path) -> Result<Vec<Transaction>> {
+    let json = std::fs::read_to_string(input_path)
+        .with_context(|| format!("Could not read import mapping {}", input_path.display()))?;
+    let config: GenericImportConfig = serde_json::from_str(&json)
+        .with_context(|| format!("Could not parse import mapping {}", input_path.display()))?;
+
+    if config.kind != CONFIG_KIND {
+        bail!("Unsupported import mapping kind '{}'", config.kind);
+    }
+
+    let source_path = resolve_source_path(input_path, &config.source_file);
+    let records = read_records(&source_path, &config)
+        .with_context(|| format!("Could not read source file {}", source_path.display()))?;
+
+    records
+        .iter()
+        .map(|record| {
+            record_to_transaction(record, &config)
+                .with_context(|| format!("Could not import row {}", record.row_number))
+        })
+        .collect()
+}
+
+fn preview_csv_file(path: &Path) -> Result<GenericImportFilePreview> {
+    let delimiter = detect_csv_delimiter(path)?;
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(delimiter)
+        .trim(csv::Trim::All)
+        .from_path(path)?;
+    let fields = reader.headers()?.iter().map(str::to_owned).collect();
+
+    Ok(GenericImportFilePreview {
+        fields,
+        format: GenericImportFormat::Csv,
+        delimiter: delimiter_as_string(delimiter),
+    })
+}
+
+fn preview_json_file(path: &Path) -> Result<GenericImportFilePreview> {
+    let value: Value = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+    let first =
+        first_json_record(&value).context("JSON import source did not contain an object record")?;
+    let mut fields = BTreeMap::new();
+    flatten_json("", first, &mut fields);
+
+    Ok(GenericImportFilePreview {
+        fields: fields.keys().cloned().collect(),
+        format: GenericImportFormat::Json,
+        delimiter: DEFAULT_DELIMITER.to_owned(),
+    })
+}
+
+fn read_records(source_path: &Path, config: &GenericImportConfig) -> Result<Vec<GenericRecord>> {
+    match config.format {
+        GenericImportFormat::Csv => read_csv_records(source_path, config),
+        GenericImportFormat::Json => read_json_records(source_path),
+    }
+}
+
+fn read_csv_records(
+    source_path: &Path,
+    config: &GenericImportConfig,
+) -> Result<Vec<GenericRecord>> {
+    let delimiter = config_delimiter(config)?;
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(delimiter)
+        .has_headers(config.has_headers)
+        .trim(if config.trim {
+            csv::Trim::All
+        } else {
+            csv::Trim::None
+        })
+        .from_path(source_path)?;
+
+    let headers = if config.has_headers {
+        reader
+            .headers()?
+            .iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    let mut records = Vec::new();
+    for (index, record) in reader.records().enumerate() {
+        let record = record?;
+        let mut fields = BTreeMap::new();
+
+        for (column_index, value) in record.iter().enumerate() {
+            let key = headers
+                .get(column_index)
+                .cloned()
+                .unwrap_or_else(|| format!("column_{}", column_index + 1));
+            fields.insert(key, value.to_owned());
+        }
+
+        records.push(GenericRecord {
+            row_number: index + if config.has_headers { 2 } else { 1 },
+            fields,
+        });
+    }
+
+    Ok(records)
+}
+
+fn read_json_records(source_path: &Path) -> Result<Vec<GenericRecord>> {
+    let value: Value = serde_json::from_str(&std::fs::read_to_string(source_path)?)?;
+    let records =
+        json_records(&value).context("JSON import source did not contain object records")?;
+
+    records
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let mut fields = BTreeMap::new();
+            flatten_json("", value, &mut fields);
+            Ok(GenericRecord {
+                row_number: index + 1,
+                fields,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug)]
+struct GenericRecord {
+    row_number: usize,
+    fields: BTreeMap<String, String>,
+}
+
+fn record_to_transaction(
+    record: &GenericRecord,
+    config: &GenericImportConfig,
+) -> Result<Transaction> {
+    let timestamp_raw = required_field(record, &config.fields.timestamp, "timestamp")?;
+    let timestamp = parse_timestamp(&timestamp_raw, &config.datetime_formats)?;
+
+    let incoming = read_amount(
+        record,
+        &config.fields.received_amount,
+        &config.fields.received_currency,
+        "received",
+    )?;
+    let outgoing = read_amount(
+        record,
+        &config.fields.sent_amount,
+        &config.fields.sent_currency,
+        "sent",
+    )?;
+
+    let operation_kind = operation_kind(record, config, incoming.is_some(), outgoing.is_some())?;
+    let operation = operation_kind.into_operation(incoming, outgoing)?;
+
+    let mut transaction = Transaction::new(timestamp, operation);
+    transaction.fee = read_amount(
+        record,
+        &config.fields.fee_amount,
+        &config.fields.fee_currency,
+        "fee",
+    )?;
+    transaction.value = read_amount(
+        record,
+        &config.fields.value_amount,
+        &config.fields.value_currency,
+        "value",
+    )?;
+    transaction.tx_hash = optional_field(record, &config.fields.tx_hash);
+    transaction.description = optional_field(record, &config.fields.description);
+    transaction.blockchain = optional_field(record, &config.fields.blockchain);
+
+    Ok(transaction)
+}
+
+fn operation_kind(
+    record: &GenericRecord,
+    config: &GenericImportConfig,
+    has_incoming: bool,
+    has_outgoing: bool,
+) -> Result<GenericOperationKind> {
+    if let Some(raw_type) = optional_field(record, &config.fields.transaction_type) {
+        if let Some(kind) = config.type_mappings.get(raw_type.trim()).copied() {
+            return Ok(kind);
+        }
+
+        let normalized_type = normalize_type_value(&raw_type);
+        if let Some((_, kind)) = config
+            .type_mappings
+            .iter()
+            .find(|(raw, _)| normalize_type_value(raw) == normalized_type)
+        {
+            return Ok(*kind);
+        }
+
+        return GenericOperationKind::from_builtin_label(&raw_type)
+            .with_context(|| format!("Unmapped transaction type '{}'", raw_type));
+    }
+
+    match (has_incoming, has_outgoing) {
+        (true, true) => Ok(GenericOperationKind::Trade),
+        (true, false) => Ok(GenericOperationKind::Receive),
+        (false, true) => Ok(GenericOperationKind::Send),
+        (false, false) => bail!("Missing transaction type and amount fields"),
+    }
+}
+
+fn required_field(record: &GenericRecord, field: &Option<String>, label: &str) -> Result<String> {
+    optional_field(record, field).with_context(|| format!("Missing {label} field"))
+}
+
+fn optional_field(record: &GenericRecord, field: &Option<String>) -> Option<String> {
+    let field = field.as_deref()?.trim();
+    if field.is_empty() {
+        return None;
+    }
+
+    record
+        .fields
+        .get(field)
+        .or_else(|| {
+            record
+                .fields
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(field))
+                .map(|(_, value)| value)
+        })
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn read_amount(
+    record: &GenericRecord,
+    amount_field: &Option<String>,
+    currency_field: &Option<String>,
+    label: &str,
+) -> Result<Option<Amount>> {
+    let Some(quantity_raw) = optional_field(record, amount_field) else {
+        return Ok(None);
+    };
+
+    let quantity = parse_decimal(&quantity_raw)
+        .with_context(|| format!("Could not parse {label} amount '{}'", quantity_raw))?;
+    if quantity.is_zero() {
+        return Ok(None);
+    }
+
+    let currency = required_field(record, currency_field, &format!("{label} currency"))?;
+    Ok(Some(Amount::new(quantity.abs(), currency)))
+}
+
+fn parse_decimal(raw: &str) -> Result<Decimal> {
+    let mut value = raw.trim();
+    let mut negative = false;
+
+    if value.starts_with('(') && value.ends_with(')') {
+        negative = true;
+        value = &value[1..value.len() - 1];
+    }
+
+    let normalized = value.replace(',', "").replace(' ', "");
+    let mut decimal = Decimal::from_str(&normalized)?;
+    if negative {
+        decimal = -decimal;
+    }
+    Ok(decimal)
+}
+
+fn parse_timestamp(raw: &str, formats: &[String]) -> Result<NaiveDateTime> {
+    let raw = raw.trim();
+
+    if let Ok(datetime) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(datetime.naive_utc());
+    }
+
+    for format in formats {
+        if let Ok(datetime) = NaiveDateTime::parse_from_str(raw, format) {
+            return Ok(datetime);
+        }
+        if let Ok(date) = NaiveDate::parse_from_str(raw, format) {
+            return date
+                .and_hms_opt(0, 0, 0)
+                .ok_or_else(|| anyhow!("Could not convert date to midnight"));
+        }
+    }
+
+    bail!("Could not parse timestamp '{}'", raw)
+}
+
+fn first_json_record(value: &Value) -> Option<&Value> {
+    json_records(value).and_then(|records| records.first().copied())
+}
+
+fn json_records(value: &Value) -> Option<Vec<&Value>> {
+    match value {
+        Value::Array(items) => Some(items.iter().filter(|item| item.is_object()).collect()),
+        Value::Object(map) => {
+            for key in ["transactions", "records", "items", "data"] {
+                if let Some(Value::Array(items)) = map.get(key) {
+                    return Some(items.iter().filter(|item| item.is_object()).collect());
+                }
+            }
+            Some(vec![value])
+        }
+        _ => None,
+    }
+}
+
+fn flatten_json(prefix: &str, value: &Value, fields: &mut BTreeMap<String, String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map {
+                let path = if prefix.is_empty() {
+                    key.to_owned()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                flatten_json(&path, value, fields);
+            }
+        }
+        Value::String(value) => {
+            fields.insert(prefix.to_owned(), value.clone());
+        }
+        Value::Number(value) => {
+            fields.insert(prefix.to_owned(), value.to_string());
+        }
+        Value::Bool(value) => {
+            fields.insert(prefix.to_owned(), value.to_string());
+        }
+        Value::Null | Value::Array(_) => {}
+    }
+}
+
+fn resolve_source_path(config_path: &Path, source_file: &str) -> PathBuf {
+    let source_path = Path::new(source_file);
+    if source_path.is_absolute() {
+        source_path.to_owned()
+    } else {
+        config_path
+            .parent()
+            .unwrap_or(Path::new(""))
+            .join(source_path)
+    }
+}
+
+fn config_delimiter(config: &GenericImportConfig) -> Result<u8> {
+    match config.delimiter.as_str() {
+        "\\t" | "tab" => Ok(b'\t'),
+        delimiter if delimiter.len() == 1 => Ok(delimiter.as_bytes()[0]),
+        delimiter => bail!("Unsupported CSV delimiter '{}'", delimiter),
+    }
+}
+
+fn detect_csv_delimiter(path: &Path) -> Result<u8> {
+    let file = File::open(path)?;
+    let mut first_line = String::new();
+    BufReader::new(file).read_line(&mut first_line)?;
+
+    let candidates = [b',', b';', b'\t'];
+    Ok(candidates
+        .into_iter()
+        .max_by_key(|candidate| {
+            first_line
+                .as_bytes()
+                .iter()
+                .filter(|byte| *byte == candidate)
+                .count()
+        })
+        .unwrap_or(b','))
+}
+
+fn delimiter_as_string(delimiter: u8) -> String {
+    match delimiter {
+        b'\t' => "\\t".to_owned(),
+        other => (other as char).to_string(),
+    }
+}
+
+fn normalize_type_value(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric() || *character == '-')
+        .collect()
+}
+
+#[distributed_slice(crate::TRANSACTION_SOURCES)]
+static GENERIC_IMPORT: TransactionSource = TransactionSource {
+    id: "GenericImport",
+    label: "Generic CSV/JSON mapping",
+    csv: &[],
+    detect: Some(detect_generic_import_config),
+    load_sync: Some(load_generic_import_config),
+    load_async: None,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("raccoin-{name}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_config(path: &Path, config: &GenericImportConfig) {
+        std::fs::write(path, serde_json::to_string_pretty(config).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn imports_csv_with_reusable_mapping() {
+        let dir = temp_dir("generic-csv");
+        let csv_path = dir.join("exchange.csv");
+        let config_path = dir.join("exchange.raccoin-import.json");
+        std::fs::write(
+            &csv_path,
+            "Date,Type,In Amount,In Currency,Out Amount,Out Currency,Fee Amount,Fee Currency,Tx ID,Note\n\
+             2024-01-02 03:04:05,Buy,0.5,BTC,10000,EUR,10,EUR,abc123,first buy\n\
+             2024-01-03 03:04:05,Withdrawal,,,0.1,BTC,,,def456,to wallet\n",
+        )
+        .unwrap();
+
+        let mut mappings = BTreeMap::new();
+        add_type_mappings(&mut mappings, "Buy", GenericOperationKind::Buy);
+        add_type_mappings(&mut mappings, "Withdrawal", GenericOperationKind::Send);
+
+        let config = GenericImportConfig {
+            source_file: "exchange.csv".to_owned(),
+            fields: GenericImportFields {
+                timestamp: Some("Date".to_owned()),
+                transaction_type: Some("Type".to_owned()),
+                received_amount: Some("In Amount".to_owned()),
+                received_currency: Some("In Currency".to_owned()),
+                sent_amount: Some("Out Amount".to_owned()),
+                sent_currency: Some("Out Currency".to_owned()),
+                fee_amount: Some("Fee Amount".to_owned()),
+                fee_currency: Some("Fee Currency".to_owned()),
+                tx_hash: Some("Tx ID".to_owned()),
+                description: Some("Note".to_owned()),
+                ..Default::default()
+            },
+            type_mappings: mappings,
+            ..Default::default()
+        };
+        write_config(&config_path, &config);
+
+        let txs = load_generic_import_config(&config_path).unwrap();
+        assert_eq!(txs.len(), 2);
+        assert_eq!(txs[0].tx_hash.as_deref(), Some("abc123"));
+        assert_eq!(txs[0].description.as_deref(), Some("first buy"));
+        match &txs[0].operation {
+            Operation::Trade { incoming, outgoing } => {
+                assert_eq!(incoming.quantity, dec!(0.5));
+                assert_eq!(incoming.currency, "BTC");
+                assert_eq!(outgoing.quantity, dec!(10000));
+                assert_eq!(outgoing.currency, "EUR");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+        assert_eq!(txs[0].fee.as_ref().unwrap().quantity, dec!(10));
+
+        match &txs[1].operation {
+            Operation::Send(amount) => {
+                assert_eq!(amount.quantity, dec!(0.1));
+                assert_eq!(amount.currency, "BTC");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+    }
+
+    #[test]
+    fn imports_json_array_with_nested_fields() {
+        let dir = temp_dir("generic-json");
+        let json_path = dir.join("wallet.json");
+        let config_path = dir.join("wallet.raccoin-import.json");
+        std::fs::write(
+            &json_path,
+            r#"[
+                {
+                    "created_at": "2024-02-03T04:05:06Z",
+                    "kind": "reward",
+                    "asset": { "amount": "12.5", "currency": "XLM" },
+                    "id": "json-1"
+                }
+            ]"#,
+        )
+        .unwrap();
+
+        let config = GenericImportConfig {
+            source_file: "wallet.json".to_owned(),
+            format: GenericImportFormat::Json,
+            fields: GenericImportFields {
+                timestamp: Some("created_at".to_owned()),
+                transaction_type: Some("kind".to_owned()),
+                received_amount: Some("asset.amount".to_owned()),
+                received_currency: Some("asset.currency".to_owned()),
+                tx_hash: Some("id".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        write_config(&config_path, &config);
+
+        let txs = load_generic_import_config(&config_path).unwrap();
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].tx_hash.as_deref(), Some("json-1"));
+        match &txs[0].operation {
+            Operation::Income(amount) => {
+                assert_eq!(amount.quantity, dec!(12.5));
+                assert_eq!(amount.currency, "XLM");
+            }
+            operation => panic!("Unexpected operation {operation:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_mapping_config_kind() {
+        let dir = temp_dir("generic-detect");
+        let config_path = dir.join("source.raccoin-import.json");
+        write_config(&config_path, &GenericImportConfig::default());
+
+        assert!(detect_generic_import_config(&config_path).unwrap());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1372,7 +1372,7 @@ fn initialize_ui(app: &mut App) -> Result<AppWindow, slint::PlatformError> {
     facade.set_generic_import_sell_values("sell,sale".into());
     facade.set_generic_import_receive_values("receive,received,deposit,transfer-in".into());
     facade.set_generic_import_send_values("send,sent,withdraw,withdrawal,transfer-out".into());
-    facade.set_generic_import_income_values("income,reward,rewards,mining,airdrop,staking,cashback".into());
+    facade.set_generic_import_income_values("income,reward,rewards,distribution,mining,airdrop,staking,cashback".into());
     facade.set_generic_import_expense_values("expense,payment,spend".into());
     facade.set_generic_import_fee_values("fee".into());
 
@@ -1991,16 +1991,16 @@ async fn main() -> Result<()> {
                         "Type", "Transaction Type", "Operation", "Action", "Kind", "Category"
                     ]));
                     facade.set_generic_import_received_amount_column(suggest_import_field(&fields, &[
-                        "Received Amount", "Receive Amount", "Amount Received", "Amount In", "In Amount", "Credit", "Base Amount"
+                        "Received Amount", "Receive Amount", "Amount Received", "Amount In", "In Amount", "Credit", "Change", "Base Amount"
                     ]));
                     facade.set_generic_import_received_currency_column(suggest_import_field(&fields, &[
                         "Received Currency", "Receive Currency", "Currency Received", "Currency In", "In Currency", "Asset", "Coin", "Base Currency"
                     ]));
                     facade.set_generic_import_sent_amount_column(suggest_import_field(&fields, &[
-                        "Sent Amount", "Send Amount", "Amount Sent", "Amount Out", "Out Amount", "Debit", "Quote Amount"
+                        "Sent Amount", "Send Amount", "Amount Sent", "Amount Out", "Out Amount", "Debit", "Change", "Quote Amount"
                     ]));
                     facade.set_generic_import_sent_currency_column(suggest_import_field(&fields, &[
-                        "Sent Currency", "Send Currency", "Currency Sent", "Currency Out", "Out Currency", "Quote Currency"
+                        "Sent Currency", "Send Currency", "Currency Sent", "Currency Out", "Out Currency", "Asset", "Coin", "Currency", "Quote Currency"
                     ]));
                     facade.set_generic_import_fee_amount_column(suggest_import_field(&fields, &[
                         "Fee Amount", "Fee", "Fees", "Network Fee"
@@ -2018,7 +2018,7 @@ async fn main() -> Result<()> {
                         "Tx ID", "Transaction ID", "Transaction Hash", "TxHash", "Hash", "ID"
                     ]));
                     facade.set_generic_import_description_column(suggest_import_field(&fields, &[
-                        "Description", "Note", "Notes", "Memo", "Comment"
+                        "Description", "Note", "Notes", "Memo", "Remark", "Comment"
                     ]));
                     facade.set_generic_import_blockchain_column(suggest_import_field(&fields, &[
                         "Blockchain", "Chain", "Network"
@@ -2027,7 +2027,7 @@ async fn main() -> Result<()> {
                     facade.set_generic_import_sell_values("sell,sale".into());
                     facade.set_generic_import_receive_values("receive,received,deposit,transfer-in".into());
                     facade.set_generic_import_send_values("send,sent,withdraw,withdrawal,transfer-out".into());
-                    facade.set_generic_import_income_values("income,reward,rewards,mining,airdrop,staking,cashback".into());
+                    facade.set_generic_import_income_values("income,reward,rewards,distribution,mining,airdrop,staking,cashback".into());
                     facade.set_generic_import_expense_values("expense,payment,spend".into());
                     facade.set_generic_import_fee_values("fee".into());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod esplora;
 mod etherscan;
 mod fifo;
 mod ftx;
+mod generic_import;
 mod horizon;
 mod kraken;
 mod liquid;
@@ -49,7 +50,7 @@ use linkme::distributed_slice;
 use std::{
     cell::RefCell,
     cmp::{Eq, Ordering},
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     default::Default,
     env,
     ffi::{OsStr, OsString},
@@ -1289,6 +1290,70 @@ fn calculate_tax_reports(transactions: &mut Vec<Transaction>, tracking: CostBasi
     reports
 }
 
+fn shared_string_model(items: Vec<String>) -> ModelRc<SharedString> {
+    let items: Vec<SharedString> = items.into_iter().map(SharedString::from).collect();
+    Rc::new(VecModel::from(items)).into()
+}
+
+fn normalize_import_field_name(name: &str) -> String {
+    name
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .collect()
+}
+
+fn suggest_import_field(fields: &[String], candidates: &[&str]) -> SharedString {
+    let normalized_candidates: Vec<String> = candidates
+        .iter()
+        .map(|candidate| normalize_import_field_name(candidate))
+        .collect();
+
+    for field in fields {
+        let normalized_field = normalize_import_field_name(field);
+        if normalized_candidates.iter().any(|candidate| *candidate == normalized_field) {
+            return field.as_str().into();
+        }
+    }
+
+    for field in fields {
+        let normalized_field = normalize_import_field_name(field);
+        if normalized_candidates
+            .iter()
+            .any(|candidate| normalized_field.contains(candidate) || candidate.contains(&normalized_field))
+        {
+            return field.as_str().into();
+        }
+    }
+
+    "".into()
+}
+
+fn trim_to_option(value: SharedString) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_owned())
+    }
+}
+
+fn import_config_source_file(config_path: &Path, source_path: &Path) -> String {
+    let config_dir = config_path.parent().unwrap_or(Path::new(""));
+    pathdiff::diff_paths(source_path, config_dir)
+        .unwrap_or_else(|| source_path.to_owned())
+        .to_string_lossy()
+        .to_string()
+}
+
+fn import_format_id(format: generic_import::GenericImportFormat) -> &'static str {
+    match format {
+        generic_import::GenericImportFormat::Csv => "csv",
+        generic_import::GenericImportFormat::Json => "json",
+    }
+}
+
 fn initialize_ui(app: &mut App) -> Result<AppWindow, slint::PlatformError> {
     let ui = AppWindow::new()?;
     app.ui_weak = ui.as_weak();
@@ -1301,6 +1366,15 @@ fn initialize_ui(app: &mut App) -> Result<AppWindow, slint::PlatformError> {
         .collect();
     source_types.sort();
     facade.set_source_types(Rc::new(VecModel::from(source_types)).into());
+    facade.set_generic_import_fields(shared_string_model(vec![String::new()]));
+    facade.set_generic_import_date_format("%Y-%m-%d %H:%M:%S".into());
+    facade.set_generic_import_buy_values("buy,purchase".into());
+    facade.set_generic_import_sell_values("sell,sale".into());
+    facade.set_generic_import_receive_values("receive,received,deposit,transfer-in".into());
+    facade.set_generic_import_send_values("send,sent,withdraw,withdrawal,transfer-out".into());
+    facade.set_generic_import_income_values("income,reward,rewards,mining,airdrop,staking,cashback".into());
+    facade.set_generic_import_expense_values("expense,payment,spend".into());
+    facade.set_generic_import_fee_values("fee".into());
 
     facade.set_wallets(app.ui_wallets.clone().into());
     facade.set_transactions(app.ui_transactions.clone().into());
@@ -1868,6 +1942,238 @@ async fn main() -> Result<()> {
         }
     });
 
+    facade.on_start_generic_import({
+        let app = app.clone();
+
+        move |_wallet_index| {
+            let mut app = app.borrow_mut();
+            let ui = app.ui();
+            let facade = ui.global::<Facade>();
+
+            facade.set_generic_import_source_path("".into());
+
+            let mut dialog = rfd::FileDialog::new()
+                .set_title("Add Generic Transaction Source")
+                .add_filter("CSV/JSON", &["csv", "json"])
+                .add_filter("CSV", &["csv"])
+                .add_filter("JSON", &["json"]);
+
+            if let Some(last_source_directory) = &app.state.last_source_directory {
+                println!("Using last source directory: {}", last_source_directory.display());
+                dialog = dialog.set_directory(last_source_directory);
+            }
+
+            let Some(file_name) = dialog.pick_file() else {
+                return;
+            };
+
+            match generic_import::preview_import_file(&file_name) {
+                Ok(preview) => {
+                    let fields = preview.fields;
+                    let source_name = file_name
+                        .file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .unwrap_or("Generic import")
+                        .to_owned();
+
+                    let mut field_options = vec![String::new()];
+                    field_options.extend(fields.iter().cloned());
+                    facade.set_generic_import_fields(shared_string_model(field_options));
+                    facade.set_generic_import_source_path(file_name.to_string_lossy().to_string().into());
+                    facade.set_generic_import_format(import_format_id(preview.format).into());
+                    facade.set_generic_import_delimiter(preview.delimiter.into());
+                    facade.set_generic_import_name(source_name.into());
+                    facade.set_generic_import_date_format("%Y-%m-%d %H:%M:%S".into());
+                    facade.set_generic_import_timestamp_column(suggest_import_field(&fields, &[
+                        "Timestamp (UTC)", "Timestamp", "Date Time", "Datetime", "Date", "Time", "Created At", "Created"
+                    ]));
+                    facade.set_generic_import_type_column(suggest_import_field(&fields, &[
+                        "Type", "Transaction Type", "Operation", "Action", "Kind", "Category"
+                    ]));
+                    facade.set_generic_import_received_amount_column(suggest_import_field(&fields, &[
+                        "Received Amount", "Receive Amount", "Amount Received", "Amount In", "In Amount", "Credit", "Base Amount"
+                    ]));
+                    facade.set_generic_import_received_currency_column(suggest_import_field(&fields, &[
+                        "Received Currency", "Receive Currency", "Currency Received", "Currency In", "In Currency", "Asset", "Coin", "Base Currency"
+                    ]));
+                    facade.set_generic_import_sent_amount_column(suggest_import_field(&fields, &[
+                        "Sent Amount", "Send Amount", "Amount Sent", "Amount Out", "Out Amount", "Debit", "Quote Amount"
+                    ]));
+                    facade.set_generic_import_sent_currency_column(suggest_import_field(&fields, &[
+                        "Sent Currency", "Send Currency", "Currency Sent", "Currency Out", "Out Currency", "Quote Currency"
+                    ]));
+                    facade.set_generic_import_fee_amount_column(suggest_import_field(&fields, &[
+                        "Fee Amount", "Fee", "Fees", "Network Fee"
+                    ]));
+                    facade.set_generic_import_fee_currency_column(suggest_import_field(&fields, &[
+                        "Fee Currency", "Fee Asset", "Fee Coin"
+                    ]));
+                    facade.set_generic_import_value_amount_column(suggest_import_field(&fields, &[
+                        "Fiat Amount", "Value Amount", "Reference Value", "Reference Price", "EUR Value"
+                    ]));
+                    facade.set_generic_import_value_currency_column(suggest_import_field(&fields, &[
+                        "Fiat Currency", "Value Currency", "Reference Currency"
+                    ]));
+                    facade.set_generic_import_tx_hash_column(suggest_import_field(&fields, &[
+                        "Tx ID", "Transaction ID", "Transaction Hash", "TxHash", "Hash", "ID"
+                    ]));
+                    facade.set_generic_import_description_column(suggest_import_field(&fields, &[
+                        "Description", "Note", "Notes", "Memo", "Comment"
+                    ]));
+                    facade.set_generic_import_blockchain_column(suggest_import_field(&fields, &[
+                        "Blockchain", "Chain", "Network"
+                    ]));
+                    facade.set_generic_import_buy_values("buy,purchase".into());
+                    facade.set_generic_import_sell_values("sell,sale".into());
+                    facade.set_generic_import_receive_values("receive,received,deposit,transfer-in".into());
+                    facade.set_generic_import_send_values("send,sent,withdraw,withdrawal,transfer-out".into());
+                    facade.set_generic_import_income_values("income,reward,rewards,mining,airdrop,staking,cashback".into());
+                    facade.set_generic_import_expense_values("expense,payment,spend".into());
+                    facade.set_generic_import_fee_values("fee".into());
+
+                    app.state.last_source_directory = file_name.parent().map(Path::to_owned);
+                }
+                Err(error) => {
+                    app.report_error(&format!("Could not inspect import source: {error:#}"));
+                }
+            }
+        }
+    });
+
+    facade.on_save_generic_import({
+        let app = app.clone();
+
+        move |wallet_index| {
+            let mut app = app.borrow_mut();
+            let ui = app.ui();
+            let facade = ui.global::<Facade>();
+
+            let source_path = PathBuf::from(facade.get_generic_import_source_path().to_string());
+            if source_path.as_os_str().is_empty() {
+                app.report_error("Choose a CSV or JSON file before adding an import mapping.");
+                return;
+            }
+
+            let config_path = source_path.with_extension("raccoin-import.json");
+            let format = match facade.get_generic_import_format().to_string().as_str() {
+                "json" => generic_import::GenericImportFormat::Json,
+                _ => generic_import::GenericImportFormat::Csv,
+            };
+
+            let mut type_mappings = BTreeMap::new();
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_buy_values().as_str(),
+                generic_import::GenericOperationKind::Buy,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_sell_values().as_str(),
+                generic_import::GenericOperationKind::Sell,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_receive_values().as_str(),
+                generic_import::GenericOperationKind::Receive,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_send_values().as_str(),
+                generic_import::GenericOperationKind::Send,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_income_values().as_str(),
+                generic_import::GenericOperationKind::Income,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_expense_values().as_str(),
+                generic_import::GenericOperationKind::Expense,
+            );
+            generic_import::add_type_mappings(
+                &mut type_mappings,
+                facade.get_generic_import_fee_values().as_str(),
+                generic_import::GenericOperationKind::Fee,
+            );
+
+            let mut datetime_formats = Vec::new();
+            if let Some(format) = trim_to_option(facade.get_generic_import_date_format()) {
+                datetime_formats.push(format);
+            }
+            for format in generic_import::default_datetime_formats() {
+                if !datetime_formats.contains(&format) {
+                    datetime_formats.push(format);
+                }
+            }
+
+            let config = generic_import::GenericImportConfig {
+                source_file: import_config_source_file(&config_path, &source_path),
+                format,
+                delimiter: facade.get_generic_import_delimiter().to_string(),
+                datetime_formats,
+                fields: generic_import::GenericImportFields {
+                    timestamp: trim_to_option(facade.get_generic_import_timestamp_column()),
+                    transaction_type: trim_to_option(facade.get_generic_import_type_column()),
+                    received_amount: trim_to_option(facade.get_generic_import_received_amount_column()),
+                    received_currency: trim_to_option(facade.get_generic_import_received_currency_column()),
+                    sent_amount: trim_to_option(facade.get_generic_import_sent_amount_column()),
+                    sent_currency: trim_to_option(facade.get_generic_import_sent_currency_column()),
+                    fee_amount: trim_to_option(facade.get_generic_import_fee_amount_column()),
+                    fee_currency: trim_to_option(facade.get_generic_import_fee_currency_column()),
+                    value_amount: trim_to_option(facade.get_generic_import_value_amount_column()),
+                    value_currency: trim_to_option(facade.get_generic_import_value_currency_column()),
+                    tx_hash: trim_to_option(facade.get_generic_import_tx_hash_column()),
+                    description: trim_to_option(facade.get_generic_import_description_column()),
+                    blockchain: trim_to_option(facade.get_generic_import_blockchain_column()),
+                },
+                type_mappings,
+                ..Default::default()
+            };
+
+            if config.fields.timestamp.is_none() {
+                app.report_error("A timestamp field is required for a generic import mapping.");
+                return;
+            }
+
+            let write_result = serde_json::to_string_pretty(&config)
+                .context("Could not serialize import mapping")
+                .and_then(|json| std::fs::write(&config_path, json).context("Could not write import mapping"));
+
+            if let Err(error) = write_result {
+                app.report_error(&format!("Could not save import mapping: {error:#}"));
+                return;
+            }
+
+            let source_name = trim_to_option(facade.get_generic_import_name()).unwrap_or_else(|| {
+                source_path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .unwrap_or("Generic import")
+                    .to_owned()
+            });
+
+            if let Some(wallet) = app.portfolio.wallets.get_mut(wallet_index as usize) {
+                wallet.sources.push(WalletSource {
+                    source_type: "GenericImport".to_owned(),
+                    path: config_path.to_string_lossy().to_string(),
+                    name: source_name,
+                    enabled: true,
+                    full_path: config_path.clone(),
+                    transaction_count: 0,
+                    transactions: Vec::new(),
+                });
+
+                app.refresh_transactions();
+                app.refresh_ui();
+                app.save_portfolio(None);
+                app.report_info(&format!("Added generic import mapping {}", config_path.display()));
+            } else {
+                app.report_error("Could not find wallet for generic import mapping.");
+            }
+        }
+    });
+
     facade.on_add_source_csv({
         let app = app.clone();
 
@@ -1875,7 +2181,9 @@ async fn main() -> Result<()> {
             let mut app = app.borrow_mut();
             let mut dialog = rfd::FileDialog::new()
                 .set_title("Add Transaction Source")
-                .add_filter("CSV", &["csv"]);
+                .add_filter("CSV/JSON", &["csv", "json"])
+                .add_filter("CSV", &["csv"])
+                .add_filter("JSON", &["json"]);
 
             if let Some(last_source_directory) = &app.state.last_source_directory {
                 println!("Using last source directory: {}", last_source_directory.display());


### PR DESCRIPTION
Fixes #42.

## Summary
- Add a reusable `GenericImport` transaction source backed by shareable `.raccoin-import.json` mapping files.
- Support generic CSV imports with delimiter detection, saved timestamp/type/amount/fee/value/id/note/blockchain field mappings, and configurable transaction-type values.
- Support signed single-column account statements, including Binance-style `UTC_Time`, `Operation`, `Coin`, `Change`, and `Remark` exports, by mapping the signed change column to both received and sent fields.
- Support generic JSON imports by flattening top-level and nested object fields from JSON arrays or common wrapper keys such as `transactions`, `records`, `items`, and `data`.
- Add a Wallets -> Add Source -> CSV/JSON Assistant flow for creating the mapping through the UI, and allow existing JSON mapping files to be added through the known-source file picker.
- Add focused tests for CSV mapping, JSON mapping, signed-change statement rows, and mapping-config detection.

## Validation
- `rustfmt --edition 2024 --check src/generic_import.rs`
- `git diff --check`
- `cargo test generic_import`
- `cargo check`
- `cargo test`

Note: I did not apply global `cargo fmt`, because the current repository baseline would reformat many unrelated existing files with the installed formatter.

Prepared with AI assistance.